### PR TITLE
Use jenkins image by jenkins ( and not by docker )

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -459,7 +459,7 @@
     "categories": ["continuous-integration"],
     "platform": "linux",
     "logo": "https://cloudinovasi.id/assets/img/logos/jenkins.png",
-    "image": "jenkins:latest",
+    "image": "jenkins/jenkins:lts",
     "ports": [
       "8080/tcp",
       "50000/tcp"


### PR DESCRIPTION
_/jenkins is deprecated : see here https://hub.docker.com/_/jenkins/

They say to use jenkins/jenkins in the future .