### PR TITLE
feat(templates): add YoutubeDL-Material template

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -881,6 +881,38 @@
 			]
 		},
 		{
+			"type": 1,
+			"title": "YoutubeDL-Material",
+			"description": "Open-source and self-hosted YouTube downloader based on Material Design",
+			"categories": [
+				"downloading"
+			],
+			"platform": "linux",
+			"logo": "https://i.imgur.com/IKOlr0N.png",
+			"image": "tzahi12345/youtubedl-material:latest",
+			"env": [{
+				"name": "ALLOW_CONFIG_MUTATIONS",
+				"set": "true"
+			}],
+			"ports": [
+				"8998/tcp",
+				"17442/tcp"
+			],
+			"volumes": [{
+					"container": "/app/appdata"
+				},
+				{
+					"container": "/app/audio"
+				},
+				{
+					"container": "/app/video"
+				},
+				{
+					"container": "/app/subscriptions"
+				}
+			]
+		},
+		{
 			"type": 2,
 			"title": "Portainer Agent",
 			"description": "Manage all the resources in your Swarm cluster",


### PR DESCRIPTION
Adds [YoutubeDL-Material](https://github.com/Tzahi12345/YoutubeDL-Material) (disclaimer: my project!). It has Docker support and is quite simple to deploy.

Let me know if there's anything you'd like to see changed. Thanks!