### PR TITLE
fix(templates): filebrowser path flag

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -824,7 +824,7 @@
 					"container": "/srv"
 				}
 			],
-			"command": "--port 80 --database /data/database.db --scope /srv"
+			"command": "--port 80 --database /data/database.db --root /srv"
 		},
 		{
 			"type": 1,


### PR DESCRIPTION
Since https://github.com/filebrowser/filebrowser/commit/5a83d6736b5053365281512e0dd8b4178ca35281 the --scope flag was renamed to --root, but the Portainer template remained with the old flag, causing containers created with the Filebrowser template to not work.

This pull request fixes that issue by renaming the old --scope flag to the current --root flag.