### PR TITLE
Update elasticsearch image version

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -206,7 +206,7 @@
 			],
 			"platform": "linux",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/elasticsearch.png",
-			"image": "elasticsearch:latest",
+			"image": "elasticsearch:7.10.1",
 			"ports": [
 				"9200/tcp",
 				"9300/tcp"


### PR DESCRIPTION
fix #96 by pointing to the latest elasticsearch image

As we see on the official dockerhub page https://hub.docker.com/_/elasticsearch?tab=description
`Note: Pulling an images requires using a specific version number tag. The latest tag is not supported.`