### PR TITLE
fix(template): use caddy:latest instead of outdated abiosoft/caddy:latest

### DIFF
--- a/templates-1.20.0.json
+++ b/templates-1.20.0.json
@@ -46,11 +46,11 @@
     "categories": ["webserver"],
     "platform": "linux",
     "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
-    "image": "abiosoft/caddy:latest",
+    "image": "caddy:latest",
     "ports": [
-      "80/tcp", "443/tcp", "2015/tcp"
+      "80/tcp", "443/tcp", "2019/tcp"
     ],
-    "volumes": [{"container": "/root/.caddy"}]
+    "volumes": [{"container": "/config"},{"container":"/data"}]
   },
   {
     "type": 1,

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -65,15 +65,20 @@
 			],
 			"platform": "linux",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
-			"image": "abiosoft/caddy:latest",
+			"image": "caddy:latest",
 			"ports": [
 				"80/tcp",
 				"443/tcp",
-				"2015/tcp"
+				"2019/tcp"
 			],
-			"volumes": [{
-				"container": "/root/.caddy"
-			}]
+			"volumes": [
+				{
+					"container": "/config"
+				},
+				{
+					"container": "/data"
+				}
+			]
 		},
 		{
 			"type": 1,

--- a/templates.json
+++ b/templates.json
@@ -46,11 +46,11 @@
     "categories": ["webserver"],
     "platform": "linux",
     "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
-    "image": "abiosoft/caddy:latest",
+    "image": "caddy:latest",
     "ports": [
-      "80/tcp", "443/tcp", "2015/tcp"
+      "80/tcp", "443/tcp", "2019/tcp"
     ],
-    "volumes": ["/root/.caddy"]
+    "volumes": ["/config","/data"]
   },
   {
     "type": "container",


### PR DESCRIPTION
I noticed the template for caddy was using the outdated and unsupported caddy-v1 version, which the official caddy container `caddy:latest` does not, 

So i made this quick edit to update it.

It is untested as I am unaware as of this moment how to test custom templates in portainer