### PR TITLE
Fix: SQL Server Linux container image location

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -314,7 +314,7 @@
 			"platform": "linux",
 			"note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
-			"image": "microsoft/mssql-server-linux:2017-GA",
+			"image": "mcr.microsoft.com/mssql/server:2019-latest",
 			"ports": [
 				"1433/tcp"
 			],


### PR DESCRIPTION
SQL Server Linux container address has changed in Docker Hub:

mcr.microsoft.com/mssql/server:2019-latest

Details - https://hub.docker.com/_/microsoft-mssql-server