### PR TITLE
Templates update

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -206,7 +206,7 @@
 			],
 			"platform": "linux",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/elasticsearch.png",
-			"image": "elasticsearch:latest",
+			"image": "docker.elastic.co/elasticsearch/elasticsearch:7.15.1",
 			"ports": [
 				"9200/tcp",
 				"9300/tcp"

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -614,15 +614,11 @@
 			],
 			"platform": "linux",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/jenkins.png",
-			"image": "jenkins/jenkins:lts",
+			"image": "jenkins/jenkins:lts-jdk11",
 			"ports": [
 				"8080/tcp",
 				"50000/tcp"
 			],
-			"env": [{
-				"name": "JENKINS_OPTS",
-				"label": "Jenkins options"
-			}],
 			"volumes": [{
 				"container": "/var/jenkins_home"
 			}]

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -88,7 +88,12 @@
 			"env": [{
 				"name": "MYSQL_ROOT_PASSWORD",
 				"label": "Root password"
-			}],
+				},
+				{
+					"name": "MYSQL_ROOT_HOST",
+					"set": "%"
+				}
+			],
 			"ports": [
 				"3306/tcp"
 			],

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -91,21 +91,19 @@
 		{
 			"type":1,
 			"title":"Caddy",
-			"description":"HTTP/2 web server with automatic HTTPS",
+			"description":"Open-source web server with automatic HTTPS written in Go",
 			"categories":[
 				"webserver"
 			],
 			"platform":"linux",
 			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
-			"image":"abiosoft/caddy:latest",
+			"image":"caddy:latest",
 			"ports":[
-				"80/tcp",
-				"443/tcp",
-				"2015/tcp"
+				"80/tcp"
 			],
 			"volumes":[
 				{
-					"container":"/root/.caddy"
+					"container":"/data"
 				}
 			]
 		},

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -257,12 +257,12 @@
 				"9000/tcp"
 			],
 			"env": [{
-					"name": "MINIO_ACCESS_KEY",
-					"label": "Minio access key"
+					"name": "MINIO_ROOT_USER",
+					"label": "Root user"
 				},
 				{
-					"name": "MINIO_SECRET_KEY",
-					"label": "Minio secret key"
+					"name": "MINIO_ROOT_PASSWORD",
+					"label": "Root password"
 				}
 			],
 			"volumes": [{

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -607,36 +607,6 @@
 		},
 		{
 			"type": 1,
-			"title": "Wowza",
-			"description": "Streaming media server",
-			"categories": [
-				"streaming"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wowza.png",
-			"image": "sameersbn/wowza:4.1.2-8",
-			"env": [{
-					"name": "WOWZA_ACCEPT_LICENSE",
-					"label": "Agree to Wowza EULA",
-					"set": "yes"
-				},
-				{
-					"name": "WOWZA_KEY",
-					"label": "License key"
-				}
-			],
-			"ports": [
-				"1935/tcp",
-				"8086/tcp",
-				"8087/tcp",
-				"8088/tcp"
-			],
-			"volumes": [{
-				"container": "/var/lib/wowza"
-			}]
-		},
-		{
-			"type": 1,
 			"title": "Jenkins",
 			"description": "Open-source continuous integration tool",
 			"categories": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -308,7 +308,8 @@
 			],
 			"env": [{
 					"name": "ACCEPT_EULA",
-					"set": "Y"
+					"default": "Y",
+					"preset": true
 				},
 				{
 					"name": "SA_PASSWORD",
@@ -332,7 +333,8 @@
 			],
 			"env": [{
 					"name": "ACCEPT_EULA",
-					"set": "Y"
+					"default": "Y",
+					"preset": true
 				},
 				{
 					"name": "sa_password",
@@ -359,7 +361,8 @@
 			],
 			"env": [{
 					"name": "ACCEPT_EULA",
-					"set": "Y"
+					"default": "Y",
+					"preset": true
 				},
 				{
 					"name": "sa_password",
@@ -678,7 +681,8 @@
 			"image": "ortussolutions/commandbox:latest",
 			"env": [{
 				"name": "CFENGINE",
-				"set": "lucee@4.5"
+				"default": "lucee@4.5",
+				"preset": true
 			}],
 			"ports": [
 				"8080/tcp",
@@ -697,15 +701,19 @@
 			"image": "ortussolutions/contentbox:latest",
 			"env": [{
 					"name": "express",
-					"set": "true"
+					"default": "true",
+					"preset": true
+
 				},
 				{
 					"name": "install",
-					"set": "true"
+					"default": "true",
+					"preset": true
 				},
 				{
 					"name": "CFENGINE",
-					"set": "lucee@4.5"
+					"default": "lucee@4.5",
+					"preset": true
 				}
 			],
 			"ports": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -162,25 +162,6 @@
 		},
 		{
 			"type": 1,
-			"title": "CockroachDB",
-			"description": "An open-source, survivable, strongly consistent, scale-out SQL database",
-			"categories": [
-				"database"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",
-			"image": "cockroachdb/cockroach:latest",
-			"ports": [
-				"26257/tcp",
-				"8080/tcp"
-			],
-			"volumes": [{
-				"container": "/cockroach/cockroach-data"
-			}],
-			"command": "start --insecure"
-		},
-		{
-			"type": 1,
 			"title": "CrateDB",
 			"description": "An open-source distributed SQL database",
 			"categories": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -19,6 +19,19 @@
 		},
 		{
 			"type": 1,
+			"title": "Ubuntu",
+			"description": "Debian-based Linux operating system",
+			"categories": [
+				"operating-system"
+			],
+			"platform": "linux",
+			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ubuntu.png",
+			"image": "ubuntu:latest",
+			"interactive": true,
+			"command": "/bin/bash"
+		},
+		{
+			"type": 1,
 			"title": "Nginx",
 			"description": "High performance web server",
 			"categories": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1,940 +1,1018 @@
 {
-	"version": "2",
-	"templates": [{
-			"type": 1,
-			"title": "Registry",
-			"description": "Docker image registry",
-			"categories": [
+	"version":"2",
+	"templates":[
+		{
+			"type":1,
+			"title":"Registry",
+			"description":"Docker image registry",
+			"categories":[
 				"docker"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/registry.png",
-			"image": "registry:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/registry.png",
+			"image":"registry:latest",
+			"ports":[
 				"5000/tcp"
 			],
-			"volumes": [{
-				"container": "/var/lib/registry"
-			}]
-		},
-		{
-			"type": 1,
-			"title": "Ubuntu",
-			"description": "Debian-based Linux operating system",
-			"categories": [
-				"operating-system"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ubuntu.png",
-			"image": "ubuntu:latest",
-			"interactive": true,
-			"command": "/bin/bash"
-		},
-		{
-			"type": 1,
-			"title": "NodeJS",
-			"description": "JavaScript-based platform for server-side and networking applications",
-			"categories": [
-				"development"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/node.png",
-			"image": "node:latest",
-			"interactive": true,
-			"command": "/bin/bash"
-		},		
-		{
-			"type": 1,
-			"title": "Nginx",
-			"description": "High performance web server",
-			"categories": [
-				"webserver"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/nginx.png",
-			"image": "nginx:latest",
-			"ports": [
-				"80/tcp",
-				"443/tcp"
-			],
-			"volumes": [{
-					"container": "/etc/nginx"
-				},
+			"volumes":[
 				{
-					"container": "/usr/share/nginx/html"
+					"container":"/var/lib/registry"
 				}
 			]
 		},
 		{
-			"type": 1,
-			"title": "Httpd",
-			"description": "Open-source HTTP server",
-			"categories": [
-				"webserver"
+			"type":1,
+			"title":"Ubuntu",
+			"description":"Debian-based Linux operating system",
+			"categories":[
+				"operating-system"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/httpd.png",
-			"image": "httpd:latest",
-			"ports": [
-				"80/tcp"
-			],
-			"volumes": [{
-				"container": "/usr/local/apache2/htdocs/"
-			}]
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ubuntu.png",
+			"image":"ubuntu:latest",
+			"interactive":true,
+			"command":"/bin/bash"
 		},
 		{
-			"type": 1,
-			"title": "Caddy",
-			"description": "HTTP/2 web server with automatic HTTPS",
-			"categories": [
+			"type":1,
+			"title":"NodeJS",
+			"description":"JavaScript-based platform for server-side and networking applications",
+			"categories":[
+				"development"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/node.png",
+			"image":"node:latest",
+			"interactive":true,
+			"command":"/bin/bash"
+		},
+		{
+			"type":1,
+			"title":"Nginx",
+			"description":"High performance web server",
+			"categories":[
 				"webserver"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
-			"image": "abiosoft/caddy:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/nginx.png",
+			"image":"nginx:latest",
+			"ports":[
+				"80/tcp",
+				"443/tcp"
+			],
+			"volumes":[
+				{
+					"container":"/etc/nginx"
+				},
+				{
+					"container":"/usr/share/nginx/html"
+				}
+			]
+		},
+		{
+			"type":1,
+			"title":"Httpd",
+			"description":"Open-source HTTP server",
+			"categories":[
+				"webserver"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/httpd.png",
+			"image":"httpd:latest",
+			"ports":[
+				"80/tcp"
+			],
+			"volumes":[
+				{
+					"container":"/usr/local/apache2/htdocs/"
+				}
+			]
+		},
+		{
+			"type":1,
+			"title":"Caddy",
+			"description":"HTTP/2 web server with automatic HTTPS",
+			"categories":[
+				"webserver"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
+			"image":"abiosoft/caddy:latest",
+			"ports":[
 				"80/tcp",
 				"443/tcp",
 				"2015/tcp"
 			],
-			"volumes": [{
-				"container": "/root/.caddy"
-			}]
+			"volumes":[
+				{
+					"container":"/root/.caddy"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "MySQL",
-			"description": "The most popular open-source database",
-			"categories": [
+			"type":1,
+			"title":"MySQL",
+			"description":"The most popular open-source database",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mysql.png",
-			"image": "mysql/mysql-server:5.7",
-			"env": [{
-				"name": "MYSQL_ROOT_PASSWORD",
-				"label": "Root password"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mysql.png",
+			"image":"mysql/mysql-server:5.7",
+			"env":[
+				{
+					"name":"MYSQL_ROOT_PASSWORD",
+					"label":"Root password"
 				},
 				{
-					"name": "MYSQL_ROOT_HOST",
-					"default": "%",
-					"preset": true
+					"name":"MYSQL_ROOT_HOST",
+					"default":"%",
+					"preset":true
 				}
 			],
-			"ports": [
+			"ports":[
 				"3306/tcp"
 			],
-			"volumes": [{
-				"container": "/var/lib/mysql"
-			}]
+			"volumes":[
+				{
+					"container":"/var/lib/mysql"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "MariaDB",
-			"description": "Performance beyond MySQL",
-			"categories": [
+			"type":1,
+			"title":"MariaDB",
+			"description":"Performance beyond MySQL",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
-			"image": "mariadb:latest",
-			"env": [{
-				"name": "MYSQL_ROOT_PASSWORD",
-				"label": "Root password"
-			}],
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
+			"image":"mariadb:latest",
+			"env":[
+				{
+					"name":"MYSQL_ROOT_PASSWORD",
+					"label":"Root password"
+				}
+			],
+			"ports":[
 				"3306/tcp"
 			],
-			"volumes": [{
-				"container": "/var/lib/mysql"
-			}]
+			"volumes":[
+				{
+					"container":"/var/lib/mysql"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "PostgreSQL",
-			"description": "The most advanced open-source database",
-			"categories": [
+			"type":1,
+			"title":"PostgreSQL",
+			"description":"The most advanced open-source database",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/postgres.png",
-			"image": "postgres:latest",
-			"env": [{
-					"name": "POSTGRES_USER",
-					"label": "Superuser"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/postgres.png",
+			"image":"postgres:latest",
+			"env":[
+				{
+					"name":"POSTGRES_USER",
+					"label":"Superuser"
 				},
 				{
-					"name": "POSTGRES_PASSWORD",
-					"label": "Superuser password"
+					"name":"POSTGRES_PASSWORD",
+					"label":"Superuser password"
 				}
 			],
-			"ports": [
+			"ports":[
 				"5432/tcp"
 			],
-			"volumes": [{
-				"container": "/var/lib/postgresql/data"
-			}]
+			"volumes":[
+				{
+					"container":"/var/lib/postgresql/data"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Mongo",
-			"description": "Open-source document-oriented database",
-			"categories": [
+			"type":1,
+			"title":"Mongo",
+			"description":"Open-source document-oriented database",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mongo.png",
-			"image": "mongo:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mongo.png",
+			"image":"mongo:latest",
+			"ports":[
 				"27017/tcp"
 			],
-			"volumes": [{
-				"container": "/data/db"
-			}]
+			"volumes":[
+				{
+					"container":"/data/db"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "CrateDB",
-			"description": "An open-source distributed SQL database",
-			"categories": [
+			"type":1,
+			"title":"CrateDB",
+			"description":"An open-source distributed SQL database",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cratedb.png",
-			"image": "crate:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cratedb.png",
+			"image":"crate:latest",
+			"ports":[
 				"4200/tcp",
 				"4300/tcp"
 			],
-			"volumes": [{
-				"container": "/data"
-			}]
+			"volumes":[
+				{
+					"container":"/data"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Elasticsearch",
-			"description": "Open-source search and analytics engine",
-			"categories": [
+			"type":1,
+			"title":"Elasticsearch",
+			"description":"Open-source search and analytics engine",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/elasticsearch.png",
-			"image": "docker.elastic.co/elasticsearch/elasticsearch:7.15.1",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/elasticsearch.png",
+			"image":"docker.elastic.co/elasticsearch/elasticsearch:7.15.1",
+			"ports":[
 				"9200/tcp",
 				"9300/tcp"
 			],
-			"volumes": [{
-				"container": "/usr/share/elasticsearch/data"
-			}]
+			"volumes":[
+				{
+					"container":"/usr/share/elasticsearch/data"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Gitlab CE",
-			"description": "Open-source end-to-end software development platform",
-			"note": "Default username is <b>root</b>. Check the <a href=\"https://docs.gitlab.com/omnibus/docker/README.html#after-starting-a-container\" target=\"_blank\">Gitlab documentation</a> to get started.",
-			"categories": [
+			"type":1,
+			"title":"Gitlab CE",
+			"description":"Open-source end-to-end software development platform",
+			"note":"Default username is <b>root</b>. Check the <a href=\"https://docs.gitlab.com/omnibus/docker/README.html#after-starting-a-container\" target=\"_blank\">Gitlab documentation</a> to get started.",
+			"categories":[
 				"development",
 				"project-management"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/gitlab_ce.png",
-			"image": "gitlab/gitlab-ce:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/gitlab_ce.png",
+			"image":"gitlab/gitlab-ce:latest",
+			"ports":[
 				"80/tcp",
 				"443/tcp",
 				"22/tcp"
 			],
-			"volumes": [{
-					"container": "/etc/gitlab"
+			"volumes":[
+				{
+					"container":"/etc/gitlab"
 				},
 				{
-					"container": "/var/log/gitlab"
+					"container":"/var/log/gitlab"
 				},
 				{
-					"container": "/var/opt/gitlab"
+					"container":"/var/opt/gitlab"
 				}
 			]
 		},
 		{
-			"type": 1,
-			"title": "Minio",
-			"description": "A distributed object storage server built for cloud applications and devops",
-			"categories": [
+			"type":1,
+			"title":"Minio",
+			"description":"A distributed object storage server built for cloud applications and devops",
+			"categories":[
 				"storage"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/minio.png",
-			"image": "quay.io/minio/minio:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/minio.png",
+			"image":"quay.io/minio/minio:latest",
+			"ports":[
 				"9000/tcp",
 				"9001/tcp"
 			],
-			"env": [{
-					"name": "MINIO_ROOT_USER",
-					"label": "Root user"
+			"env":[
+				{
+					"name":"MINIO_ROOT_USER",
+					"label":"Root user"
 				},
 				{
-					"name": "MINIO_ROOT_PASSWORD",
-					"label": "Root password"
+					"name":"MINIO_ROOT_PASSWORD",
+					"label":"Root password"
 				}
 			],
-			"volumes": [{
-					"container": "/data"
+			"volumes":[
+				{
+					"container":"/data"
 				},
 				{
-					"container": "/root/.minio"
+					"container":"/root/.minio"
 				}
 			],
-			"command": "server /data --console-address ':9001'"
+			"command":"server /data --console-address ':9001'"
 		},
 		{
-			"type": 1,
-			"title": "Scality S3",
-			"description": "Standalone AWS S3 protocol server",
-			"categories": [
+			"type":1,
+			"title":"Scality S3",
+			"description":"Standalone AWS S3 protocol server",
+			"categories":[
 				"storage"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/scality-s3.png",
-			"image": "scality/s3server",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/scality-s3.png",
+			"image":"scality/s3server",
+			"ports":[
 				"8000/tcp"
 			],
-			"env": [{
-					"name": "SCALITY_ACCESS_KEY",
-					"label": "Scality S3 access key"
+			"env":[
+				{
+					"name":"SCALITY_ACCESS_KEY",
+					"label":"Scality S3 access key"
 				},
 				{
-					"name": "SCALITY_SECRET_KEY",
-					"label": "Scality S3 secret key"
+					"name":"SCALITY_SECRET_KEY",
+					"label":"Scality S3 secret key"
 				}
 			],
-			"volumes": [{
-					"container": "/usr/src/app/localData"
+			"volumes":[
+				{
+					"container":"/usr/src/app/localData"
 				},
 				{
-					"container": "/usr/src/app/localMetadata"
-				}
-			]
-		},
-		{
-			"type": 1,
-			"title": "SQL Server",
-			"description": "Microsoft SQL Server on Linux",
-			"categories": [
-				"database"
-			],
-			"platform": "linux",
-			"note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
-			"image": "mcr.microsoft.com/mssql/server:2019-latest",
-			"ports": [
-				"1433/tcp"
-			],
-			"env": [{
-					"name": "ACCEPT_EULA",
-					"default": "Y",
-					"preset": true
-				},
-				{
-					"name": "SA_PASSWORD",
-					"label": "SA password"
+					"container":"/usr/src/app/localMetadata"
 				}
 			]
 		},
 		{
-			"type": 1,
-			"title": "SQL Server",
-			"description": "Microsoft SQL Server Developer for Windows containers",
-			"categories": [
+			"type":1,
+			"title":"SQL Server",
+			"description":"Microsoft SQL Server on Linux",
+			"categories":[
 				"database"
 			],
-			"platform": "windows",
-			"note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
-			"image": "microsoft/mssql-server-windows-developer:latest",
-			"ports": [
+			"platform":"linux",
+			"note":"Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+			"image":"mcr.microsoft.com/mssql/server:2019-latest",
+			"ports":[
 				"1433/tcp"
 			],
-			"env": [{
-					"name": "ACCEPT_EULA",
-					"default": "Y",
-					"preset": true
+			"env":[
+				{
+					"name":"ACCEPT_EULA",
+					"default":"Y",
+					"preset":true
 				},
 				{
-					"name": "sa_password",
-					"label": "SA password"
+					"name":"SA_PASSWORD",
+					"label":"SA password"
 				}
-			],
-			"volumes": [{
-				"container": "C:/temp/"
-			}]
+			]
 		},
 		{
-			"type": 1,
-			"title": "SQL Server Express",
-			"description": "Microsoft SQL Server Express for Windows containers",
-			"categories": [
+			"type":1,
+			"title":"SQL Server",
+			"description":"Microsoft SQL Server Developer for Windows containers",
+			"categories":[
 				"database"
 			],
-			"platform": "windows",
-			"note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
-			"image": "microsoft/mssql-server-windows-express:latest",
-			"ports": [
+			"platform":"windows",
+			"note":"Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+			"image":"microsoft/mssql-server-windows-developer:latest",
+			"ports":[
 				"1433/tcp"
 			],
-			"env": [{
-					"name": "ACCEPT_EULA",
-					"default": "Y",
-					"preset": true
+			"env":[
+				{
+					"name":"ACCEPT_EULA",
+					"default":"Y",
+					"preset":true
 				},
 				{
-					"name": "sa_password",
-					"label": "SA password"
+					"name":"sa_password",
+					"label":"SA password"
 				}
 			],
-			"volumes": [{
-				"container": "C:/temp/"
-			}]
+			"volumes":[
+				{
+					"container":"C:/temp/"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Solr",
-			"description": "Open-source enterprise search platform",
-			"categories": [
+			"type":1,
+			"title":"SQL Server Express",
+			"description":"Microsoft SQL Server Express for Windows containers",
+			"categories":[
+				"database"
+			],
+			"platform":"windows",
+			"note":"Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+			"image":"microsoft/mssql-server-windows-express:latest",
+			"ports":[
+				"1433/tcp"
+			],
+			"env":[
+				{
+					"name":"ACCEPT_EULA",
+					"default":"Y",
+					"preset":true
+				},
+				{
+					"name":"sa_password",
+					"label":"SA password"
+				}
+			],
+			"volumes":[
+				{
+					"container":"C:/temp/"
+				}
+			]
+		},
+		{
+			"type":1,
+			"title":"Solr",
+			"description":"Open-source enterprise search platform",
+			"categories":[
 				"search-engine"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/solr.png",
-			"image": "solr:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/solr.png",
+			"image":"solr:latest",
+			"ports":[
 				"8983/tcp"
 			],
-			"volumes": [{
-				"container": "/opt/solr/mydata"
-			}]
+			"volumes":[
+				{
+					"container":"/opt/solr/mydata"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Redis",
-			"description": "Open-source in-memory data structure store",
-			"categories": [
+			"type":1,
+			"title":"Redis",
+			"description":"Open-source in-memory data structure store",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redis.png",
-			"image": "redis:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redis.png",
+			"image":"redis:latest",
+			"ports":[
 				"6379/tcp"
 			],
-			"volumes": [{
-				"container": "/data"
-			}]
+			"volumes":[
+				{
+					"container":"/data"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "RabbitMQ",
-			"description": "Highly reliable enterprise messaging system",
-			"categories": [
+			"type":1,
+			"title":"RabbitMQ",
+			"description":"Highly reliable enterprise messaging system",
+			"categories":[
 				"messaging"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/rabbitmq.png",
-			"image": "rabbitmq:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/rabbitmq.png",
+			"image":"rabbitmq:latest",
+			"ports":[
 				"5671/tcp",
 				"5672/tcp"
 			],
-			"volumes": [{
-				"container": "/var/lib/rabbitmq"
-			}]
+			"volumes":[
+				{
+					"container":"/var/lib/rabbitmq"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Ghost",
-			"description": "Free and open-source blogging platform",
-			"categories": [
+			"type":1,
+			"title":"Ghost",
+			"description":"Free and open-source blogging platform",
+			"categories":[
 				"blog"
 			],
-			"note": "Access the blog management interface under <code>/ghost/</code>.",
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ghost.png",
-			"image": "ghost:latest",
-			"ports": [
+			"note":"Access the blog management interface under <code>/ghost/</code>.",
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ghost.png",
+			"image":"ghost:latest",
+			"ports":[
 				"2368/tcp"
 			],
-			"volumes": [{
-				"container": "/var/lib/ghost/content"
-			}]
+			"volumes":[
+				{
+					"container":"/var/lib/ghost/content"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Joomla",
-			"description": "Another free and open-source CMS",
-			"categories": [
+			"type":1,
+			"title":"Joomla",
+			"description":"Another free and open-source CMS",
+			"categories":[
 				"CMS"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/joomla.png",
-			"image": "joomla:latest",
-			"env": [{
-					"name": "JOOMLA_DB_HOST",
-					"label": "MySQL database host",
-					"type": "container"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/joomla.png",
+			"image":"joomla:latest",
+			"env":[
+				{
+					"name":"JOOMLA_DB_HOST",
+					"label":"MySQL database host",
+					"type":"container"
 				},
 				{
-					"name": "JOOMLA_DB_PASSWORD",
-					"label": "Database password"
+					"name":"JOOMLA_DB_PASSWORD",
+					"label":"Database password"
 				}
 			],
-			"ports": [
+			"ports":[
 				"80/tcp"
 			],
-			"volumes": [{
-				"container": "/var/www/html"
-			}]
+			"volumes":[
+				{
+					"container":"/var/www/html"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Drupal",
-			"description": "Open-source content management framework",
-			"categories": [
+			"type":1,
+			"title":"Drupal",
+			"description":"Open-source content management framework",
+			"categories":[
 				"CMS"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/drupal.png",
-			"image": "drupal:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/drupal.png",
+			"image":"drupal:latest",
+			"ports":[
 				"80/tcp"
 			],
-			"volumes": [{
-				"container": "/var/www/html"
-			}]
+			"volumes":[
+				{
+					"container":"/var/www/html"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Plone",
-			"description": "A free and open-source CMS built on top of Zope",
-			"note": "Default user and password are admin/admin",
-			"categories": [
+			"type":1,
+			"title":"Plone",
+			"description":"A free and open-source CMS built on top of Zope",
+			"note":"Default user and password are admin/admin",
+			"categories":[
 				"CMS"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plone.png",
-			"image": "plone:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plone.png",
+			"image":"plone:latest",
+			"ports":[
 				"8080/tcp"
 			],
-			"volumes": [{
-				"container": "/data"
-			}]
+			"volumes":[
+				{
+					"container":"/data"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Magento 2",
-			"description": "Open-source e-commerce platform",
-			"categories": [
+			"type":1,
+			"title":"Magento 2",
+			"description":"Open-source e-commerce platform",
+			"categories":[
 				"CMS"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/magento.png",
-			"image": "alankent/gsd:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/magento.png",
+			"image":"alankent/gsd:latest",
+			"ports":[
 				"80/tcp",
 				"3000/tcp",
 				"3001/tcp"
 			],
-			"volumes": [{
-				"container": "/var/www/html/"
-			}]
-		},
-		{
-			"type": 1,
-			"title": "Sematext Docker Agent",
-			"description": "Collect logs, metrics and docker events",
-			"categories": [
-				"Log Management",
-				"Monitoring"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
-			"image": "sematext/sematext-agent-docker:latest",
-			"name": "sematext-agent",
-			"privileged": true,
-			"env": [{
-					"name": "LOGSENE_TOKEN",
-					"label": "Logs token"
-				},
+			"volumes":[
 				{
-					"name": "SPM_TOKEN",
-					"label": "SPM monitoring token"
-				}
-			],
-			"volumes": [{
-				"container": "/var/run/docker.sock",
-				"bind": "/var/run/docker.sock"
-			}]
-		},
-		{
-			"type": 1,
-			"title": "Datadog agent",
-			"description": "Collect events and metrics",
-			"categories": [
-				"Monitoring"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
-			"image": "datadog/agent:latest",
-			"env": [{
-				"name": "DD_API_KEY",
-				"label": "Datadog API key"
-			}],
-			"volumes": [{
-					"container": "/var/run/docker.sock",
-					"bind": "/var/run/docker.sock",
-					"readonly": true
-				},
-				{
-					"container": "/host/sys/fs/cgroup",
-					"bind": "/sys/fs/cgroup",
-					"readonly": true
-				},
-				{
-					"container": "/host/proc",
-					"bind": "/proc",
-					"readonly": true
+					"container":"/var/www/html/"
 				}
 			]
 		},
 		{
-			"type": 1,
-			"title": "Mautic",
-			"description": "Open-source marketing automation platform",
-			"categories": [
-				"marketing"
+			"type":1,
+			"title":"Sematext Docker Agent",
+			"description":"Collect logs, metrics and docker events",
+			"categories":[
+				"Log Management",
+				"Monitoring"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mautic.png",
-			"image": "mautic/mautic:latest",
-			"env": [{
-					"name": "MAUTIC_DB_HOST",
-					"label": "MySQL database host",
-					"type": "container"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
+			"image":"sematext/sematext-agent-docker:latest",
+			"name":"sematext-agent",
+			"privileged":true,
+			"env":[
+				{
+					"name":"LOGSENE_TOKEN",
+					"label":"Logs token"
 				},
 				{
-					"name": "MAUTIC_DB_PASSWORD",
-					"label": "Database password"
+					"name":"SPM_TOKEN",
+					"label":"SPM monitoring token"
 				}
 			],
-			"ports": [
-				"80/tcp"
-			],
-			"volumes": [{
-				"container": "/var/www/html"
-			}]
+			"volumes":[
+				{
+					"container":"/var/run/docker.sock",
+					"bind":"/var/run/docker.sock"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Jenkins",
-			"description": "Open-source continuous integration tool",
-			"categories": [
+			"type":1,
+			"title":"Datadog agent",
+			"description":"Collect events and metrics",
+			"categories":[
+				"Monitoring"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
+			"image":"datadog/agent:latest",
+			"env":[
+				{
+					"name":"DD_API_KEY",
+					"label":"Datadog API key"
+				}
+			],
+			"volumes":[
+				{
+					"container":"/var/run/docker.sock",
+					"bind":"/var/run/docker.sock",
+					"readonly":true
+				},
+				{
+					"container":"/host/sys/fs/cgroup",
+					"bind":"/sys/fs/cgroup",
+					"readonly":true
+				},
+				{
+					"container":"/host/proc",
+					"bind":"/proc",
+					"readonly":true
+				}
+			]
+		},
+		{
+			"type":1,
+			"title":"Mautic",
+			"description":"Open-source marketing automation platform",
+			"categories":[
+				"marketing"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mautic.png",
+			"image":"mautic/mautic:latest",
+			"env":[
+				{
+					"name":"MAUTIC_DB_HOST",
+					"label":"MySQL database host",
+					"type":"container"
+				},
+				{
+					"name":"MAUTIC_DB_PASSWORD",
+					"label":"Database password"
+				}
+			],
+			"ports":[
+				"80/tcp"
+			],
+			"volumes":[
+				{
+					"container":"/var/www/html"
+				}
+			]
+		},
+		{
+			"type":1,
+			"title":"Jenkins",
+			"description":"Open-source continuous integration tool",
+			"categories":[
 				"continuous-integration"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/jenkins.png",
-			"image": "jenkins/jenkins:lts-jdk11",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/jenkins.png",
+			"image":"jenkins/jenkins:lts-jdk11",
+			"ports":[
 				"8080/tcp",
 				"50000/tcp"
 			],
-			"volumes": [{
-				"container": "/var/jenkins_home"
-			}]
+			"volumes":[
+				{
+					"container":"/var/jenkins_home"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "Redmine",
-			"description": "Open-source project management tool",
-			"note": "Default user and password are admin/admin",
-			"categories": [
+			"type":1,
+			"title":"Redmine",
+			"description":"Open-source project management tool",
+			"note":"Default user and password are admin/admin",
+			"categories":[
 				"project-management"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redmine.png",
-			"image": "redmine:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redmine.png",
+			"image":"redmine:latest",
+			"ports":[
 				"3000/tcp"
 			],
-			"volumes": [{
-				"container": "/usr/src/redmine/files"
-			}]
+			"volumes":[
+				{
+					"container":"/usr/src/redmine/files"
+				}
+			]
 		},
 		{
-			"type": 1,
-			"title": "File browser",
-			"description": "A web file manager",
-			"note": "Default credentials: admin/admin",
-			"categories": [
+			"type":1,
+			"title":"File browser",
+			"description":"A web file manager",
+			"note":"Default credentials: admin/admin",
+			"categories":[
 				"filesystem",
 				"storage"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/filebrowser.png",
-			"image": "filebrowser/filebrowser:latest",
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/filebrowser.png",
+			"image":"filebrowser/filebrowser:latest",
+			"ports":[
 				"80/tcp"
 			],
-			"volumes": [{
-					"container": "/data"
+			"volumes":[
+				{
+					"container":"/data"
 				},
 				{
-					"container": "/srv"
+					"container":"/srv"
 				}
 			],
-			"command": "--port 80 --database /data/database.db --root /srv"
+			"command":"--port 80 --database /data/database.db --root /srv"
 		},
 		{
-			"type": 1,
-			"title": "CommandBox",
-			"description": "ColdFusion (CFML) CLI",
-			"categories": [
+			"type":1,
+			"title":"CommandBox",
+			"description":"ColdFusion (CFML) CLI",
+			"categories":[
 				"development"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-commandbox.png",
-			"image": "ortussolutions/commandbox:latest",
-			"env": [{
-				"name": "CFENGINE",
-				"default": "lucee@4.5",
-				"preset": true
-			}],
-			"ports": [
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-commandbox.png",
+			"image":"ortussolutions/commandbox:latest",
+			"env":[
+				{
+					"name":"CFENGINE",
+					"default":"lucee@4.5",
+					"preset":true
+				}
+			],
+			"ports":[
 				"8080/tcp",
 				"8443/tcp"
 			]
 		},
 		{
-			"type": 1,
-			"title": "ContentBox",
-			"description": "Open-source modular CMS",
-			"categories": [
+			"type":1,
+			"title":"ContentBox",
+			"description":"Open-source modular CMS",
+			"categories":[
 				"CMS"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-contentbox.png",
-			"image": "ortussolutions/contentbox:latest",
-			"env": [{
-					"name": "express",
-					"default": "true",
-					"preset": true
-
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-contentbox.png",
+			"image":"ortussolutions/contentbox:latest",
+			"env":[
+				{
+					"name":"express",
+					"default":"true",
+					"preset":true
 				},
 				{
-					"name": "install",
-					"default": "true",
-					"preset": true
+					"name":"install",
+					"default":"true",
+					"preset":true
 				},
 				{
-					"name": "CFENGINE",
-					"default": "lucee@4.5",
-					"preset": true
+					"name":"CFENGINE",
+					"default":"lucee@4.5",
+					"preset":true
 				}
 			],
-			"ports": [
+			"ports":[
 				"8080/tcp",
 				"8443/tcp"
 			],
-			"volumes": [{
-					"container": "/data/contentbox/db"
+			"volumes":[
+				{
+					"container":"/data/contentbox/db"
 				},
 				{
-					"container": "/app/includes/shared/media"
+					"container":"/app/includes/shared/media"
 				}
 			]
 		},
 		{
-			"type": 2,
-			"title": "Portainer Agent",
-			"description": "Manage all the resources in your Swarm cluster",
-			"note": "The agent will be deployed globally inside your cluster and available on port 9001.",
-			"categories": [
+			"type":2,
+			"title":"Portainer Agent",
+			"description":"Manage all the resources in your Swarm cluster",
+			"note":"The agent will be deployed globally inside your cluster and available on port 9001.",
+			"categories":[
 				"portainer"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/portainer-agent/docker-stack.yml"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/portainer-agent/docker-stack.yml"
 			}
 		},
 		{
-			"type": 2,
-			"title": "OpenFaaS",
-			"name": "func",
-			"description": "Serverless functions made simple",
-			"note": "Deploys the API gateway and sample functions. You can access the UI on port 8080. <b>Warning</b>: the name of the stack must be 'func'.",
-			"categories": [
+			"type":2,
+			"title":"OpenFaaS",
+			"name":"func",
+			"description":"Serverless functions made simple",
+			"note":"Deploys the API gateway and sample functions. You can access the UI on port 8080. <b>Warning</b>: the name of the stack must be 'func'.",
+			"categories":[
 				"serverless"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/openfaas.png",
-			"repository": {
-				"url": "https://github.com/openfaas/faas",
-				"stackfile": "docker-compose.yml"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/openfaas.png",
+			"repository":{
+				"url":"https://github.com/openfaas/faas",
+				"stackfile":"docker-compose.yml"
 			}
 		},
 		{
-			"type": 2,
-			"title": "IronFunctions",
-			"description": "Open-source serverless computing platform",
-			"note": "Deploys the IronFunctions API and UI.",
-			"categories": [
+			"type":2,
+			"title":"IronFunctions",
+			"description":"Open-source serverless computing platform",
+			"note":"Deploys the IronFunctions API and UI.",
+			"categories":[
 				"serverless"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/ironfunctions/docker-stack.yml"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/ironfunctions/docker-stack.yml"
 			}
 		},
 		{
-			"type": 2,
-			"title": "CockroachDB",
-			"description": "CockroachDB cluster",
-			"note": "Deploys an insecure CockroachDB cluster, please refer to <a href=\"https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-docker-swarm.html\" target=\"_blank\">CockroachDB documentation</a> for production deployments.",
-			"categories": [
+			"type":2,
+			"title":"CockroachDB",
+			"description":"CockroachDB cluster",
+			"note":"Deploys an insecure CockroachDB cluster, please refer to <a href=\"https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-docker-swarm.html\" target=\"_blank\">CockroachDB documentation</a> for production deployments.",
+			"categories":[
 				"database"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/cockroachdb/docker-stack.yml"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/cockroachdb/docker-stack.yml"
 			}
 		},
 		{
-			"type": 2,
-			"title": "Wordpress",
-			"description": "Wordpress setup with a MySQL database",
-			"note": "Deploys a Wordpress instance connected to a MySQL database.",
-			"categories": [
+			"type":2,
+			"title":"Wordpress",
+			"description":"Wordpress setup with a MySQL database",
+			"note":"Deploys a Wordpress instance connected to a MySQL database.",
+			"categories":[
 				"CMS"
 			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wordpress.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/wordpress/docker-stack.yml"
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wordpress.png",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/wordpress/docker-stack.yml"
 			},
-			"env": [{
-				"name": "MYSQL_DATABASE_PASSWORD",
-				"label": "Database root password",
-				"description": "Password used by the MySQL root user."
-			}]
-		},
-		{
-			"type": 3,
-			"title": "Wordpress",
-			"description": "Wordpress setup with a MySQL database",
-			"note": "Deploys a Wordpress instance connected to a MySQL database.",
-			"categories": [
-				"CMS"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wordpress.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/wordpress/docker-compose.yml"
-			},
-			"env": [{
-				"name": "MYSQL_DATABASE_PASSWORD",
-				"label": "Database root password",
-				"description": "Password used by the MySQL root user."
-			}]
-		},
-		{
-			"type": 2,
-			"title": "Microsoft OMS Agent",
-			"description": "Microsoft Operations Management Suite Linux agent.",
-			"categories": [
-				"OPS"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/microsoft-oms/docker-stack.yml"
-			},
-			"env": [{
-					"name": "AZURE_WORKSPACE_ID",
-					"label": "Workspace ID",
-					"description": "Azure Workspace ID"
-				},
+			"env":[
 				{
-					"name": "AZURE_PRIMARY_KEY",
-					"label": "Primary key",
-					"description": "Azure primary key"
+					"name":"MYSQL_DATABASE_PASSWORD",
+					"label":"Database root password",
+					"description":"Password used by the MySQL root user."
 				}
 			]
 		},
 		{
-			"title": "Sematext Docker Agent",
-			"type": 2,
-			"categories": [
+			"type":3,
+			"title":"Wordpress",
+			"description":"Wordpress setup with a MySQL database",
+			"note":"Deploys a Wordpress instance connected to a MySQL database.",
+			"categories":[
+				"CMS"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wordpress.png",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/wordpress/docker-compose.yml"
+			},
+			"env":[
+				{
+					"name":"MYSQL_DATABASE_PASSWORD",
+					"label":"Database root password",
+					"description":"Password used by the MySQL root user."
+				}
+			]
+		},
+		{
+			"type":2,
+			"title":"Microsoft OMS Agent",
+			"description":"Microsoft Operations Management Suite Linux agent.",
+			"categories":[
+				"OPS"
+			],
+			"platform":"linux",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/microsoft-oms/docker-stack.yml"
+			},
+			"env":[
+				{
+					"name":"AZURE_WORKSPACE_ID",
+					"label":"Workspace ID",
+					"description":"Azure Workspace ID"
+				},
+				{
+					"name":"AZURE_PRIMARY_KEY",
+					"label":"Primary key",
+					"description":"Azure primary key"
+				}
+			]
+		},
+		{
+			"title":"Sematext Docker Agent",
+			"type":2,
+			"categories":[
 				"Log Management",
 				"Monitoring"
 			],
-			"description": "Collect logs, metrics and docker events",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
-			"platform": "linux",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/sematext-agent-docker/docker-stack.yml"
+			"description":"Collect logs, metrics and docker events",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
+			"platform":"linux",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/sematext-agent-docker/docker-stack.yml"
 			},
-			"env": [{
-					"name": "LOGSENE_TOKEN",
-					"label": "Logs token"
+			"env":[
+				{
+					"name":"LOGSENE_TOKEN",
+					"label":"Logs token"
 				},
 				{
-					"name": "SPM_TOKEN",
-					"label": "SPM monitoring token"
+					"name":"SPM_TOKEN",
+					"label":"SPM monitoring token"
 				}
 			]
 		},
 		{
-			"title": "Datadog agent",
-			"type": 2,
-			"categories": [
+			"title":"Datadog agent",
+			"type":2,
+			"categories":[
 				"Monitoring"
 			],
-			"description": "Collect events and metrics",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
-			"platform": "linux",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "stacks/datadog-agent/docker-stack.yml"
+			"description":"Collect events and metrics",
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
+			"platform":"linux",
+			"repository":{
+				"url":"https://github.com/portainer/templates",
+				"stackfile":"stacks/datadog-agent/docker-stack.yml"
 			},
-			"env": [{
-				"name": "API_KEY",
-				"label": "Datadog API key"
-			}]
+			"env":[
+				{
+					"name":"API_KEY",
+					"label":"Datadog API key"
+				}
+			]
 		},
 		{
-	    "type": 4,
-	    "title": "Wordpress",
-	    "description": "Wordpress setup with a MySQL database",
-	    "note": "Deploys a Wordpress instance connected to a MySQL database.",
-	    "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/stacks/wordpress/edge/docker-stack.yml"
-	  },
-	  {
-	    "type": 4,
-	    "title": "CockroachDB",
-	    "description": "CockroachDB cluster",
-	    "note": "Deploys an insecure CockroachDB cluster, please refer to <a href=\"https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-docker-swarm.html\" target=\"_blank\">CockroachDB documentation</a> for production deployments.",
-	    "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/stacks/cockroachdb/edge/docker-stack.yml"
-	  }
+			"type":4,
+			"title":"Wordpress",
+			"description":"Wordpress setup with a MySQL database",
+			"note":"Deploys a Wordpress instance connected to a MySQL database.",
+			"stackfile":"https://raw.githubusercontent.com/portainer/templates/master/stacks/wordpress/edge/docker-stack.yml"
+		},
+		{
+			"type":4,
+			"title":"CockroachDB",
+			"description":"CockroachDB cluster",
+			"note":"Deploys an insecure CockroachDB cluster, please refer to <a href=\"https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-docker-swarm.html\" target=\"_blank\">CockroachDB documentation</a> for production deployments.",
+			"stackfile":"https://raw.githubusercontent.com/portainer/templates/master/stacks/cockroachdb/edge/docker-stack.yml"
+		}
 	]
 }

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -84,7 +84,7 @@
 			],
 			"platform": "linux",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mysql.png",
-			"image": "mysql:latest",
+			"image": "mysql/mysql-server:5.7",
 			"env": [{
 				"name": "MYSQL_ROOT_PASSWORD",
 				"label": "Root password"

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -584,27 +584,6 @@
 		},
 		{
 			"type":1,
-			"title":"Magento 2",
-			"description":"Open-source e-commerce platform",
-			"categories":[
-				"CMS"
-			],
-			"platform":"linux",
-			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/magento.png",
-			"image":"alankent/gsd:latest",
-			"ports":[
-				"80/tcp",
-				"3000/tcp",
-				"3001/tcp"
-			],
-			"volumes":[
-				{
-					"container":"/var/www/html/"
-				}
-			]
-		},
-		{
-			"type":1,
 			"title":"Sematext Docker Agent",
 			"description":"Collect logs, metrics and docker events",
 			"categories":[

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -32,6 +32,19 @@
 		},
 		{
 			"type": 1,
+			"title": "NodeJS",
+			"description": "JavaScript-based platform for server-side and networking applications",
+			"categories": [
+				"development"
+			],
+			"platform": "linux",
+			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/node.png",
+			"image": "node:latest",
+			"interactive": true,
+			"command": "/bin/bash"
+		},		
+		{
+			"type": 1,
 			"title": "Nginx",
 			"description": "High performance web server",
 			"categories": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -91,7 +91,8 @@
 				},
 				{
 					"name": "MYSQL_ROOT_HOST",
-					"set": "%"
+					"default": "%",
+					"preset": true
 				}
 			],
 			"ports": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -436,27 +436,6 @@
 		},
 		{
 			"type": 1,
-			"title": "Plesk",
-			"description": "WebOps platform and hosting control panel",
-			"categories": [
-				"CMS"
-			],
-			"platform": "linux",
-			"note": "Default credentials: admin / changeme1Q**",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plesk.png",
-			"image": "plesk/plesk:latest",
-			"ports": [
-				"8880/tcp"
-			],
-			"volumes": [{
-				  "container": "/sys/fs/cgroup",
-				  "bind": "/sys/fs/cgroup",
-				  "readonly": true
-				}
-			]
-		},
-		{
-			"type": 1,
 			"title": "Joomla",
 			"description": "Another free and open-source CMS",
 			"categories": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -442,16 +442,17 @@
 				"CMS"
 			],
 			"platform": "linux",
-			"note": "Default credentials: admin / changeme",
+			"note": "Default credentials: admin / changeme1Q**",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plesk.png",
 			"image": "plesk/plesk:latest",
 			"ports": [
-				"21/tcp",
-				"80/tcp",
-				"443/tcp",
-				"8880/tcp",
-				"8443/tcp",
-				"8447/tcp"
+				"8880/tcp"
+			],
+			"volumes": [{
+				  "container": "/sys/fs/cgroup",
+				  "bind": "/sys/fs/cgroup",
+				  "readonly": true
+				}
 			]
 		},
 		{

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -627,6 +627,7 @@
 			"type": 1,
 			"title": "Redmine",
 			"description": "Open-source project management tool",
+			"note": "Default user and password are admin/admin",
 			"categories": [
 				"project-management"
 			],
@@ -638,62 +639,6 @@
 			],
 			"volumes": [{
 				"container": "/usr/src/redmine/files"
-			}]
-		},
-		{
-			"type": 1,
-			"title": "Odoo",
-			"description": "Open-source business apps",
-			"categories": [
-				"project-management"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/odoo.png",
-			"image": "odoo:latest",
-			"env": [{
-					"name": "HOST",
-					"label": "PostgreSQL database host",
-					"type": "container"
-				},
-				{
-					"name": "USER",
-					"label": "Database user"
-				},
-				{
-					"name": "PASSWORD",
-					"label": "Database password"
-				}
-			],
-			"ports": [
-				"8069/tcp"
-			],
-			"volumes": [{
-					"container": "/var/lib/odoo"
-				},
-				{
-					"container": "/mnt/extra-addons"
-				}
-			]
-		},
-		{
-			"type": 1,
-			"title": "Urbackup",
-			"description": "Open-source network backup",
-			"categories": [
-				"backup"
-			],
-			"platform": "linux",
-			"note": "This application web interface is exposed on the port 55414 inside the container.",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/urbackup.png",
-			"image": "cfstras/urbackup",
-			"ports": [
-				"55413/tcp",
-				"55414/tcp",
-				"55415/tcp",
-				"35622/tcp"
-			],
-			"volumes": [{
-				"container": "/var/urbackup"
 			}]
 		},
 		{

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -385,46 +385,6 @@
 		},
 		{
 			"type": 1,
-			"title": "IronFunctions API",
-			"description": "Open-source serverless computing platform",
-			"categories": [
-				"serverless"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
-			"image": "iron/functions:latest",
-			"ports": [
-				"8080/tcp"
-			],
-			"volumes": [{
-				"container": "/app/data"
-			}],
-			"privileged": true
-		},
-		{
-			"type": 1,
-			"title": "IronFunctions UI",
-			"description": "Open-source user interface for IronFunctions",
-			"categories": [
-				"serverless"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
-			"image": "iron/functions-ui:latest",
-			"ports": [
-				"4000/tcp"
-			],
-			"volumes": [{
-				"container": "/app/data"
-			}],
-			"env": [{
-				"name": "API_URL",
-				"label": "API URL"
-			}],
-			"privileged": true
-		},
-		{
-			"type": 1,
 			"title": "Solr",
 			"description": "Open-source enterprise search platform",
 			"categories": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -482,6 +482,7 @@
 			"type": 1,
 			"title": "Plone",
 			"description": "A free and open-source CMS built on top of Zope",
+			"note": "Default user and password are admin/admin",
 			"categories": [
 				"CMS"
 			],

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -252,9 +252,10 @@
 			],
 			"platform": "linux",
 			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/minio.png",
-			"image": "minio/minio:latest",
+			"image": "quay.io/minio/minio:latest",
 			"ports": [
-				"9000/tcp"
+				"9000/tcp",
+				"9001/tcp"
 			],
 			"env": [{
 					"name": "MINIO_ROOT_USER",
@@ -272,7 +273,7 @@
 					"container": "/root/.minio"
 				}
 			],
-			"command": "server /data"
+			"command": "server /data --console-address ':9001'"
 		},
 		{
 			"type": 1,


### PR DESCRIPTION
First round of update/removal/addition to container templates.

Also remove the use of the `set` property to replace it with `preset` and `default` instead, this will prevent an issue in Portainer UI showing empty input labels for ENV with default values.

Update list of container templates below (added/removed/updated)

I did not test/change the following areas:

* Swarm templates
* Container templates for Windows

I left the datadog/sematext container templates because I was able to deploy them with invalid keys BUT I was not able to test them with valid keys/setup. They seem to deploy fine though.

# Update container template list 

* Removed ironfunction UI/API templates (unmaintained project)
* Removed cockroachDB container template (cannot be used like that, need a standalone stack template)
* Fixed Elastic container template (now using fixed version not latest)
* Removed plesk container template (requires tmpfs support)
* Added a note field to Plone container template to specify default credentials
* Updated Minio container template (use non deprecated env vars)
* Updated Mysql container template to lock it to mysql/mysql-server:5.7 (docker optimized, better compatibility with other apps)
* Removed Wowza container template
* Updated Jenkins container template (removed JENKINS_OPTS env)
* Removed Odoo container template (requires the use of link to work properly, wasn't able to make it works with multiple attempts)
* Removed Urbackup container template (custom built unmaintained image)
* Removed Magento container template (unmaintained image)
* Added Ubuntu container template
* Added NodeJS container template
* Updated Caddy container template to use official image


Closes #132 
Closes #127 (as plesk has container template has been removed)
Closes #96 
