### PR TITLE
Fdo container template

### DIFF
--- a/stacks/fdo/docker-stack.yml
+++ b/stacks/fdo/docker-stack.yml
@@ -24,48 +24,6 @@ services:
       - rv-target:/home/fdo/target
     network_mode: host
 
-  pri-fdo-owner:
-    image: portainer/pri-fidoiot:owner-master
-    expose:
-      - "8042"
-    ports:
-      - "8042:8042"
-      - "8043:8043"
-    environment:
-      owner_keystore_password: JPmYuPdSYOG8U3a
-      owner_api_password: ${owner_api_password}
-      owner_ssl_keystore-password: Sw2cqdcc1IM
-      ssl_truststore_password: Sw2cqdcc1IM
-      owner_to2_port: 8042
-      owner_database_connection_url: jdbc:h2:tcp://localhost:8051/./target/data/ops
-      owner_database_username: sa
-      owner_database_password: ""
-      owner_database_port: 8051
-      catalina_home: ./target/tomcat
-      owner_keystore: ./owner_keystore.p12
-      owner_to0_scheduling_enabled: "true"
-      owner_to0_scheduling_interval: 60
-      owner_to0_rv_blob: http://localhost:8042?ipaddress=127.0.0.1
-      owner_svi_values: ./serviceinfo/sample-values
-      owner_svi_string: ./serviceinfo/sample-svi.csv
-      owner_api_user: ${owner_api_user}
-      ondie_cache: file:///home/fdo/ondie_cache/
-      ondie_autoupdate: "false"
-      ondie_zip_artifact: https://tsci.intel.com/content/csme.zip
-      ondie_check_revocations: "false"
-      owner_protocol_scheme: https
-      owner_https_port: 8043
-      owner_ssl_keystore: certs/ssl.p12
-      ssl_truststore: certs/truststore
-      ssl_truststore_type: PKCS12
-      fido_ssl_mode: TEST
-      owner_pub_key_path: owner_pub_keys.pem
-      owner2_pub_key_path: owner2_pub_keys.pem
-      log4j_configuration_file: log4j2.xml
-    volumes:
-      - owner-target:/home/fdo/target
-    network_mode: host
-
   pri-fdo-manufacturer:
     image: portainer/pri-fidoiot:manufacturer-master
     expose:

--- a/stacks/fdo/docker-stack.yml
+++ b/stacks/fdo/docker-stack.yml
@@ -17,7 +17,7 @@ services:
       rv_database_port: 8050
       catalina_home: ./target/tomcat
       rv_https_port: 8041
-      rv_protocol_scheme: https
+      rv_protocol_scheme: http
       rv_ssl_keystore: certs/ssl.p12
       log4j_configuration_file: log4j2.xml
     volumes:
@@ -46,7 +46,7 @@ services:
       ondie_autoupdate: "false"
       ondie_zip_artifact: https://tsci.intel.com/content/csme.zip
       ondie_check_revocations: "false"
-      manufacturer_protocol_scheme: https
+      manufacturer_protocol_scheme: http
       manufacturer_https_port: 8038
       manufacturer_keystore: manufacturer_keystore.p12
       manufacturer_ssl_keystore: certs/ssl.p12

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -128,6 +128,21 @@
 					"name":"owner_svi_values",
 					"default":"./serviceinfo/sample-values",
 					"preset":true
+				},
+				{
+					"name":"owner_pub_key_path",
+					"default":"owner_pub_keys.pem",
+					"preset":true
+				},
+				{
+					"name":"owner2_pub_key_path",
+					"default":"owner2_pub_keys.pem",
+					"preset":true
+				},
+				{
+					"name":"ondie_cache",
+					"default":"file:///home/fdo/ondie_cache/",
+					"preset":true
 				}
 			]
 		},

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -20,7 +20,7 @@
 					"container":"/home/fdo/target"
 				}
 			],
-			"note":"Owner server public URL must use the format http://URL:PORT?ipaddress=127.0.0.1",
+			"note":"Owner server public URL must use the format http://IP|URL:PORT?ipaddress=IP, e.g. http://owner.portainer.io?ipaddress=183.187.112.47 or http://183.187.112.47?ipaddress=183.187.112.47",
 			"env":[
 				{
 					"name":"owner_to0_rv_blob",

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -44,9 +44,6 @@
 					"default":"8043",
 					"preset":true
 				},				
-				// Am I right to assume that this was generated at build time
-				// Following these instructions ? 
-				// https://github.com/secure-device-onboard/pri-fidoiot/blob/2bac84514d02c89583585d3dfaa305681625c82a/component-samples/demo/owner/README.md#inserting-keys-into-owner-keystore
 				{
 					"name":"owner_keystore",
 					"default":"./owner_keystore.p12",

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -20,7 +20,7 @@
 					"container":"/home/fdo/target"
 				}
 			],
-			"note":"Owner server public URL must use the format http://IP|URL:PORT?ipaddress=IP, e.g. http://owner.portainer.io?ipaddress=183.187.112.47 or http://183.187.112.47?ipaddress=183.187.112.47",
+			"note":"Owner server public URL must use the format http://IP|URL:PORT?ipaddress=IP, e.g. http://owner.portainer.io:8042?ipaddress=183.187.112.47 or http://183.187.112.47:8042?ipaddress=183.187.112.47",
 			"env":[
 				{
 					"name":"owner_to0_rv_blob",
@@ -36,7 +36,7 @@
 				},
 				{
 					"name":"owner_to0_scheduling_interval",
-					"default":"60s",
+					"default":"60",
 					"preset":true
 				},
 				{

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -12,8 +12,8 @@
 			"platform":"linux",
 			"image":"portainer/pri-fidoiot:owner-master",
 			"ports":[
-				"8042/tcp",
-				"8043/tcp"
+				"8042:8042/tcp",
+				"8043:8043/tcp"
 			],
 			"volumes":[
 				{

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -158,6 +158,11 @@
 					"name":"ondie_check_revocations",
 					"default":"false",
 					"preset":true
+				},
+				{
+					"name":"fido_ssl_mode",
+					"default":"TEST",
+					"preset":true
 				}
 			]
 		},

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -40,6 +40,21 @@
 					"preset":true
 				},
 				{
+					"name":"owner_to0_scheduling_enabled",
+					"default":"true",
+					"preset":true
+				},				
+				{
+					"name":"owner_to2_port",
+					"default":"8042",
+					"preset":true
+				},
+				{
+					"name":"owner_protocol_scheme",
+					"default":"https",
+					"preset":true
+				},						
+				{
 					"name":"owner_https_port",
 					"default":"8043",
 					"preset":true
@@ -72,6 +87,46 @@
 				{
 					"name":"ssl_truststore_password",
 					"default":"Sw2cqdcc1IM",
+					"preset":true
+				},
+				{
+					"name":"log4j_configuration_file",
+					"default":"log4j2.xml",
+					"preset":true
+				},
+				{
+					"name":"catalina_home",
+					"default":"./target/tomcat",
+					"preset":true
+				},
+				{
+					"name":"owner_database_connection_url",
+					"default":"jdbc:h2:tcp://localhost:8051/./target/data/ops",
+					"preset":true
+				},
+				{
+					"name":"owner_database_username",
+					"default":"sa",
+					"preset":true
+				},
+				{
+					"name":"owner_database_password",
+					"default":"",
+					"preset":true
+				},
+				{
+					"name":"owner_database_port",
+					"default":"8051",
+					"preset":true
+				},
+				{
+					"name":"owner_svi_string",
+					"default":"./serviceinfo/sample-svi.csv",
+					"preset":true
+				},
+				{
+					"name":"owner_svi_values",
+					"default":"./serviceinfo/sample-values",
 					"preset":true
 				}
 			]

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -111,7 +111,7 @@
 				},
 				{
 					"name":"owner_database_password",
-					"default":"",
+					"default":"test",
 					"preset":true
 				},
 				{

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -143,6 +143,21 @@
 					"name":"ondie_cache",
 					"default":"file:///home/fdo/ondie_cache/",
 					"preset":true
+				},
+				{
+					"name":"ondie_autoupdate",
+					"default":"false",
+					"preset":true
+				},
+				{
+					"name":"ondie_zip_artifact",
+					"default":"https://tsci.intel.com/content/csme.zip",
+					"preset":true
+				},
+				{
+					"name":"ondie_check_revocations",
+					"default":"false",
+					"preset":true
 				}
 			]
 		},

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -2,6 +2,84 @@
 	"version":"2",
 	"templates":[
 		{
+			"type": 1,
+			"title": "FDO",
+			"description": "FDO Owner Service",
+			"categories":[
+				"edge"
+			],
+			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/intel.png",
+			"platform":"linux",
+			"image":"portainer/pri-fidoiot:owner-master",
+			"ports":[
+				"8042/tcp",
+				"8043/tcp"
+			],
+			"volumes":[
+				{
+					"container":"/home/fdo/target"
+				}
+			],
+			"note":"Owner server public URL must use the format http://URL:PORT?ipaddress=127.0.0.1",
+			"env":[
+				{
+					"name":"owner_to0_rv_blob",
+					"label": "Owner server public URL",
+				},
+				{
+					"name":"owner_api_user",
+					"label":"API user"
+				},
+				{
+					"name":"owner_api_password",
+					"label":"API password"
+				},
+				{
+					"name":"owner_to0_scheduling_interval",
+					"default":"60s",
+					"preset":true
+				},
+				{
+					"name":"owner_https_port",
+					"default":"8043",
+					"preset":true
+				},				
+				// Am I right to assume that this was generated at build time
+				// Following these instructions ? 
+				// https://github.com/secure-device-onboard/pri-fidoiot/blob/2bac84514d02c89583585d3dfaa305681625c82a/component-samples/demo/owner/README.md#inserting-keys-into-owner-keystore
+				{
+					"name":"owner_keystore",
+					"default":"./owner_keystore.p12",
+					"preset":true
+				},
+				{
+					"name":"owner_keystore_password",
+					"default":"JPmYuPdSYOG8U3a",
+					"preset":true
+				},
+				{
+					"name":"owner_ssl_keystore",
+					"default":"certs/ssl.p12",
+					"preset":true
+				},				
+				{
+					"name":"owner_ssl_keystore-password",
+					"default":"Sw2cqdcc1IM",
+					"preset":true
+				},
+				{
+					"name":"ssl_truststore",
+					"default":"certs/truststore",
+					"preset":true
+				},				
+				{
+					"name":"ssl_truststore_password",
+					"default":"Sw2cqdcc1IM",
+					"preset":true
+				}
+			]
+		},
+		{
 			"type":1,
 			"title":"Registry",
 			"description":"Docker image registry",

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -51,7 +51,7 @@
 				},
 				{
 					"name":"owner_protocol_scheme",
-					"default":"https",
+					"default":"http",
 					"preset":true
 				},						
 				{
@@ -1211,7 +1211,7 @@
 			"platform":"linux",
 			"logo":"https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/intel.png",
 			"repository":{
-				"url":"https://github.com/portainer/templates",
+				"url":"https://github.com/deviantony/templates",
 				"stackfile":"stacks/fdo/docker-stack.yml"
 			},
 			"env":[

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -24,7 +24,7 @@
 			"env":[
 				{
 					"name":"owner_to0_rv_blob",
-					"label": "Owner server public URL",
+					"label": "Owner server public URL"
 				},
 				{
 					"name":"owner_api_user",


### PR DESCRIPTION
Minimum container configuration to run the FDO Owner Service container:

```
docker run --rm \
-p 8042:8042 -p 8043:8043 \
-v fdo_owner:/home/fdo/target \
-e owner_to0_rv_blob=http://IP:8042?ipaddress=IP\
-e owner_api_user=portainer \
-e owner_api_password=portainer \
-e owner_to0_scheduling_interval=60s \
-e owner_to2_port=8042 \
-e owner_to0_scheduling_enabled="true" \
-e owner_protocol_scheme=https \
-e owner_https_port=8043 \
-e owner_keystore=./owner_keystore.p12 \
-e owner_keystore_password=JPmYuPdSYOG8U3a \
-e owner_ssl_keystore=certs/ssl.p12 \
-e owner_ssl_keystore-password=Sw2cqdcc1IM \
-e ssl_truststore=certs/truststore \
-e ssl_truststore_password=Sw2cqdcc1IM \
-e log4j_configuration_file=log4j2.xml \
-e catalina_home=./target/tomcat \
-e owner_database_connection_url=jdbc:h2:tcp://localhost:8051/./target/data/ops \
-e owner_database_username=sa \
-e owner_database_password= \
-e owner_database_port=8051 \
-e owner_svi_string=./serviceinfo/sample-svi.csv \
-e owner_svi_values=./serviceinfo/sample-values \
portainer/pri-fidoiot:owner-master
```

The application will start and output the following warnings:

```
20:56:08.202 [WARN ] Could not load property: ondie_cache
20:56:08.203 [WARN ] Could not load property: epid_online_url
20:56:08.203 [WARN ] Could not load property: epid_test_mode
20:56:08.210 [WARN ] Could not load property: owner_pub_key_path
20:56:08.211 [WARN ] Could not load property: owner2_pub_key_path
```

Not sure whether this is important or not.

Which leaves us with the (currently) optional env vars:
```
-e ondie_cache=file:///home/fdo/ondie_cache/ \
-e ondie_autoupdate="false" \
-e ondie_zip_artifact=https://tsci.intel.com/content/csme.zip \
-e ondie_check_revocations="false" \
-e fido_ssl_mode=TEST \
-e owner_pub_key_path=owner_pub_keys.pem \
-e owner2_pub_key_path=owner2_pub_keys.pem \
```