### PR TITLE
feat(template): add new liveswitch template

### DIFF
--- a/stacks/liveswitch/docker-compose.yml
+++ b/stacks/liveswitch/docker-compose.yml
@@ -1,0 +1,53 @@
+# Taken from https://github.com/jvenema/liveswitch-docker-compose/blob/main/docker-compose.yml
+version: "3"
+
+services:
+  gateway:
+    image: frozenmountain/liveswitch-gateway:latest
+    restart: 'always'
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "8443:8443"
+      - "10443:10443"
+    environment:
+      - CONNECTIONSTRINGS:DEFAULT=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
+      - CONNECTIONSTRINGS:CACHE=redis://redis
+    networks: 
+      - liveswitch
+  media:
+    # media server is super verbose...
+    #logging:
+    #  driver: none
+    image: frozenmountain/liveswitch-media-server:latest
+    restart: 'always'
+    # necessary for media servers due to dynamic port management
+    network_mode: 'host'
+    ulimits: 
+      nofile: 65535
+    environment:
+      # running on IP instead of by name due to the host network
+      - CONNECTIONSTRINGS:DEFAULT=postgres://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres
+      - CONNECTIONSTRINGS:CACHE=redis://127.0.0.1
+      - SERVICEBASEURL=http://127.0.0.1:8080
+  redis:
+    image: redis
+    restart: 'always'
+    # ports needed to support meda server running on host network
+    ports:
+      - "6379:6379"
+    networks: 
+      - liveswitch
+  postgres:
+    image: postgres
+    restart: 'always'
+    networks: 
+      - liveswitch
+    # ports needed to support meda server running on host network
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+  
+networks:
+  liveswitch:

--- a/stacks/liveswitch/docker-stack.yml
+++ b/stacks/liveswitch/docker-stack.yml
@@ -1,0 +1,53 @@
+# Taken from https://github.com/jvenema/liveswitch-docker-compose/blob/main/docker-compose.yml
+version: "3"
+
+services:
+  gateway:
+    image: frozenmountain/liveswitch-gateway:latest
+    restart: 'always'
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "8443:8443"
+      - "10443:10443"
+    environment:
+      - CONNECTIONSTRINGS:DEFAULT=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
+      - CONNECTIONSTRINGS:CACHE=redis://redis
+    networks: 
+      - liveswitch
+  media:
+    # media server is super verbose...
+    #logging:
+    #  driver: none
+    image: frozenmountain/liveswitch-media-server:latest
+    restart: 'always'
+    # necessary for media servers due to dynamic port management
+    network_mode: 'host'
+    ulimits: 
+      nofile: 65535
+    environment:
+      # running on IP instead of by name due to the host network
+      - CONNECTIONSTRINGS:DEFAULT=postgres://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres
+      - CONNECTIONSTRINGS:CACHE=redis://127.0.0.1
+      - SERVICEBASEURL=http://127.0.0.1:8080
+  redis:
+    image: redis
+    restart: 'always'
+    # ports needed to support meda server running on host network
+    ports:
+      - "6379:6379"
+    networks: 
+      - liveswitch
+  postgres:
+    image: postgres
+    restart: 'always'
+    networks: 
+      - liveswitch
+    # ports needed to support meda server running on host network
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+  
+networks:
+  liveswitch:

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1014,7 +1014,7 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        "url": "https://raw.githubusercontent.com/portainer/templates/feat_new_liveswitch_template",
+        "url": "https://github.com/portainer/templates",
         "stackfile": "stacks/liveswitch/docker-stack.yml"
       },
       "env": [
@@ -1032,7 +1032,7 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        "url": "https://raw.githubusercontent.com/portainer/templates/feat_new_liveswitch_template",
+        "url": "https://github.com/portainer/templates",
         "stackfile": "stacks/liveswitch/docker-compose.yml"
       },
       "env": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1014,8 +1014,6 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        // "url": "https://github.com/portainer/templates",
-        // "stackfile": "stacks/liveswitch/docker-stack.yml"
         "url": "https://github.com/portainer/templates/tree/feat_new_liveswitch_template",
         "stackfile": "stacks/liveswitch/docker-stack.yml"
       },
@@ -1034,8 +1032,6 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        // "url": "https://github.com/portainer/templates",
-        // "stackfile": "stacks/liveswitch/docker-compose.yml"
         "url": "https://github.com/portainer/templates/tree/feat_new_liveswitch_template",
         "stackfile": "stacks/liveswitch/docker-compose.yml"
       },

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1023,6 +1023,24 @@
           "label": "Postgres password"
         }
       ]
+    },
+    {
+      "type": 3,
+      "title": "LiveSwitch",
+      "description": "A basic LiveSwitch compose with gateway, caching, database and media server",
+      "categories": ["media"],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/liveswitch/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "POSTGRES_PASSWORD",
+          "label": "Postgres password"
+        }
+      ]
     }
   ]
 }

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1014,7 +1014,7 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        "url": "https://github.com/portainer/templates/tree/feat_new_liveswitch_template",
+        "url": "https://raw.githubusercontent.com/portainer/templates/feat_new_liveswitch_template",
         "stackfile": "stacks/liveswitch/docker-stack.yml"
       },
       "env": [
@@ -1032,7 +1032,7 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        "url": "https://github.com/portainer/templates/tree/feat_new_liveswitch_template",
+        "url": "https://raw.githubusercontent.com/portainer/templates/feat_new_liveswitch_template",
         "stackfile": "stacks/liveswitch/docker-compose.yml"
       },
       "env": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1014,7 +1014,9 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        "url": "https://github.com/portainer/templates",
+        // "url": "https://github.com/portainer/templates",
+        // "stackfile": "stacks/liveswitch/docker-stack.yml"
+        "url": "https://github.com/portainer/templates/tree/feat_new_liveswitch_template",
         "stackfile": "stacks/liveswitch/docker-stack.yml"
       },
       "env": [
@@ -1032,7 +1034,9 @@
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
-        "url": "https://github.com/portainer/templates",
+        // "url": "https://github.com/portainer/templates",
+        // "stackfile": "stacks/liveswitch/docker-compose.yml"
+        "url": "https://github.com/portainer/templates/tree/feat_new_liveswitch_template",
         "stackfile": "stacks/liveswitch/docker-compose.yml"
       },
       "env": [

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1005,6 +1005,24 @@
           "default": "443"
         }
       ]
+    },
+    {
+      "type": 2,
+      "title": "LiveSwitch",
+      "description": "A basic LiveSwitch stack with gateway, caching, database and media server",
+      "categories": ["media"],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/liveswitch/docker-stack.yml"
+      },
+      "env": [
+        {
+          "name": "POSTGRES_PASSWORD",
+          "label": "Postgres password"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Neil requested I add a new template for LiveSwitch based off of this compose file with the requested change of port 9443 to 10443: https://raw.githubusercontent.com/jvenema/liveswitch-docker-compose/main/docker-compose.yml

@deviantony It seems you're likely best to review this PR. :)