### PR TITLE
Fix wordpress not retaining website data

### DIFF
--- a/stacks/wordpress/docker-compose.yml
+++ b/stacks/wordpress/docker-compose.yml
@@ -14,6 +14,8 @@ services:
 
    wordpress:
      image: wordpress:latest
+     volumes:
+       - wordpress_data:/var/www/html
      ports:
        - 80
      restart: always
@@ -24,3 +26,4 @@ services:
 
 volumes:
     db_data:
+    wordpress_data:


### PR DESCRIPTION
This fixes that wordpress will retain its data after a restart off docker.