### PR TITLE
add cedalo-mosquitto-mc template

### DIFF
--- a/edge/cedalo-mosquitto-mc/docker-compose.yml
+++ b/edge/cedalo-mosquitto-mc/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  mosquitto:
+    image: registry.cedalo.com/portainer-trials/mosquitto:2.7.2
+    ports:
+      - 1883
+      - 8883
+      - 8090
+    environment:
+      CEDALO_LICENSE_KEY: {{ CEDALO_LICENSE_KEY }}
+      MOSQUITTO_DYNSEC_PASSWORD: {{ CEDALO_MC_BROKER_PASSWORD }}
+    volumes:
+       - mosquitto_data:/mosquitto/data
+       - mosquitto_config:/mosquitto/config
+
+  management-center:
+    image: registry.cedalo.com/portainer-trials/management-center:2.7
+    ports:
+      - 8088
+    depends_on:
+      - mosquitto
+    environment:
+      CEDALO_LICENSE_KEY: {{ CEDALO_LICENSE_KEY }}
+      CEDALO_MC_PROXY_HOST: 0.0.0.0
+      CEDALO_MC_USERNAME: cedalo
+      CEDALO_MC_PASSWORD: mmcisawesome
+      CEDALO_MC_PROXY_SRT_BASE: /management-center/config
+      CEDALO_MC_PROXY_CONFIG: /management-center/config/config.json
+      CEDALO_MC_PROXY_CONFIG_CERTS: /management-center/config/certs.db
+      CEDALO_MC_PROXY_CONFIG_TOKENS: /management-center/config/tokens.json
+      CEDALO_MC_PROXY_CONFIG_USERS: /management-center/config/users.json
+      CEDALO_MC_PROXY_CONFIG_AUDIT_TRAIL: /management-center/config/audit.json
+      CEDALO_MC_BROKER_CONNECTION_MQTT_EXISTS_MAPPING: mosquitto:true
+      CEDALO_MC_BROKER_CONNECTION_MQTTS_EXISTS_MAPPING: mosquitto:false
+      CEDALO_MC_BROKER_CONNECTION_WS_EXISTS_MAPPING: mosquitto:false
+      CEDALO_MC_BROKER_CONNECTION_HOST_MAPPING: mosquitto:localhost
+      CEDALO_MC_BROKER_URL: mqtt://mosquitto:1883
+      CEDALO_MC_BROKER_NAME: pro-mosquitto
+      CEDALO_MC_BROKER_ID: pro-mosquitto
+      CEDALO_MC_BROKER_USERNAME: admin
+      CEDALO_MC_BROKER_PASSWORD: {{ CEDALO_MC_BROKER_PASSWORD }}
+      CEDALO_MC_DATA_DIRECTORY_PATH: /management-center/config
+      CEDALO_MC_MODE: offline
+    volumes:
+       - mc_data:/management-center/config
+
+volumes:
+    mosquitto_data:
+    mosquitto_config:
+    mc_data:

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1232,10 +1232,32 @@
       ]
     },
     {
+      "type": 3,
+      "title": "Pro Mosquitto with Management Center",
+      "description": "Commercial-grade Mosquitto MQTT broker with Management Center",
+      "note": "Use <b>admin</b> as the default username to connect to the Management Center.",
+      "categories": ["edge"],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cedalo.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "edge/cedalo-mosquitto-mc/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "CEDALO_LICENSE_KEY",
+          "label": "License key"
+        },
+        {
+          "name": "CEDALO_MC_BROKER_PASSWORD",
+          "label": "Broker and management center password"
+        }
+      ]
+    },
+    {
       "type": 4,
       "title": "Softing EdgeConnector modbus",
       "description": "Connect Modbus TCP Sensors/PLCs and provide the data via OPC UA and MQTT",
-      "note": "Connect Modbus TCP Sensors/PLCs and provide the data via OPC UA and MQTT",
       "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/softing-edgeconnector-modbus/docker-compose.yml"
     },
     {
@@ -1268,6 +1290,13 @@
       "description": "No-code middleware for industrial applications",
       "note": "More information about the <a href=\"https://www.opc-router.com/terms-of-use-and-eula/?utm_source=DockerHub_runtime&utm_medium=click&utm_campaign=TermsOfUseAndEula\" target=\"_blank\">EULA</a>.",
       "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/opc-router/docker-compose.yml"
+    },
+    {
+      "type": 4,
+      "title": "Pro Mosquitto with Management Center",
+      "description": "Commercial-grade Mosquitto MQTT broker with Management Center",
+      "note": "Use <b>admin</b> as the default username to connect to the Management Center.",
+      "stackfile": "https://raw.githubusercontent.com/portainer/templates/master/edge/cedalo-mosquitto-mc/docker-compose.yml"
     }
   ]
 }


### PR DESCRIPTION
This PR introduce the Cedalo Pro Mosquitto + Management Center template for docker standalone and Edge.