### PR TITLE
Fix(readme): reference to main should be v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ For more information about the template definition format and how to deploy your
 
 **This branch (master) is Deprecated.**
 
-Since version 3 of the templates, we've moved to use `main` branch as the default branch for this repository. If you are using version 2, please use the `master` branch of this repository (or https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json).
+Since version 3 of the templates, we've moved to use `v3` branch as the default branch for this repository. If you are using version 2, please use the `master` branch of this repository (or https://raw.githubusercontent.com/portainer/templates/master/templates-2.0.json).


### PR DESCRIPTION
Fix the new default branch name in the readme.  Should be v3.