### PR TITLE
Update OPC Router docker-compose.yml to reflect needed volumes

### DIFF
--- a/edge/opc-router/docker-compose.yml
+++ b/edge/opc-router/docker-compose.yml
@@ -8,15 +8,11 @@ services:
       - "8081:8081"
     volumes:
       - type: volume
-        source: opcrouter-configdb
-        target: /data/database
-      - type: volume
-        source: opcrouter-inray
-        target: /inray
+        source: opcrouter-data
+        target: /data
       - type: volume
         source: opcrouter-logs
         target: /var/log/opcrouter
 volumes:
-  opcrouter-configdb:
-  opcrouter-inray:
+  opcrouter-data:
   opcrouter-logs:


### PR DESCRIPTION
The required volumes for the OPC Router have changed and this change ensures the template is up to date with the application requirements.