### PR TITLE
Update Grafana image to v10.4.18 to address CVE-2025-4123

### DIFF
--- a/swarm/monitoring/docker-compose.yml
+++ b/swarm/monitoring/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   grafana:
-    image: portainer/template-swarm-monitoring:grafana-9.5.2
+    image: grafana/grafana:10.4.18+security-01
     ports:
       - target: 3000
         published: 3000


### PR DESCRIPTION
This updates the Swarm monitoring stack to use the official Grafana v10.4.18 image, which includes the security fix for CVE-2025-4123 ("Grafana Ghost"). The previous image (v9.5.2) is unpatched and susceptible to client-side open redirect and plugin injection.
