### PR TITLE
Update Jenkins image version to lts-jdk21

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -634,7 +634,7 @@
       "categories": ["continuous-integration"],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/jenkins.png",
-      "image": "jenkins/jenkins:lts-jdk11",
+      "image": "jenkins/jenkins:lts-jdk21",
       "ports": ["8080/tcp", "50000/tcp"],
       "volumes": [
         {


### PR DESCRIPTION
lts-jdk11 is too old to install plugins.