### PR TITLE
Add HermitStash — post-quantum encrypted file uploads

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1571,7 +1571,7 @@
       ],
       "platform": "linux",
       "logo": "https://assets.hermitstash.com/img/icons/icon-512.png",
-      "image": "ghcr.io/dotcoocoo/hermitstash:latest",
+      "image": "ghcr.io/dotcoocoo/hermitstash:1",
       "ports": [
         "3000/tcp"
       ],
@@ -1587,6 +1587,28 @@
       ],
       "env": [
         {
+          "name": "PUID",
+          "label": "User ID",
+          "default": "1000"
+        },
+        {
+          "name": "PGID",
+          "label": "Group ID",
+          "default": "1000"
+        },
+        {
+          "name": "UMASK",
+          "label": "File permission mask",
+          "default": "022",
+          "description": "022 = 755 dirs / 644 files"
+        },
+        {
+          "name": "TZ",
+          "label": "Timezone",
+          "default": "Etc/UTC",
+          "description": "IANA timezone name, e.g. America/New_York"
+        },
+        {
           "name": "TRUST_PROXY",
           "label": "Trust Proxy",
           "default": "true",
@@ -1599,7 +1621,7 @@
           "description": "Full URL (e.g. https://files.example.com). Required for passkeys and HSTS."
         }
       ],
-      "note": "Requires --shm-size=256m for the in-memory encrypted database. After starting, visit port 3000 to complete the setup wizard.",
+      "note": "Requires --shm-size=256m for the in-memory encrypted database. Recommended runtime flags (set under Advanced container settings -> Capabilities and Runtime & Resources): cap_drop=ALL with cap_add=CHOWN,SETUID,SETGID,DAC_OVERRIDE; security_opt no-new-privileges:true; init=true. After starting, visit port 3000 to complete the setup wizard.",
       "restart_policy": "unless-stopped"
     }
   ]

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -5,11 +5,15 @@
       "type": 1,
       "title": "Registry",
       "description": "Docker image registry",
-      "categories": ["docker"],
+      "categories": [
+        "docker"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/registry.png",
       "image": "registry:latest",
-      "ports": ["5000/tcp"],
+      "ports": [
+        "5000/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/registry"
@@ -20,11 +24,15 @@
       "type": 1,
       "title": "Registry (cache)",
       "description": "Docker image registry configured as a DockerHub pull through cache",
-      "categories": ["docker"],
+      "categories": [
+        "docker"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/registry.png",
       "image": "registry:latest",
-      "ports": ["5000/tcp"],
+      "ports": [
+        "5000/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/registry"
@@ -42,7 +50,9 @@
       "type": 1,
       "title": "Ubuntu",
       "description": "Debian-based Linux operating system",
-      "categories": ["operating-system"],
+      "categories": [
+        "operating-system"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ubuntu.png",
       "image": "ubuntu:latest",
@@ -53,7 +63,9 @@
       "type": 1,
       "title": "NodeJS",
       "description": "JavaScript-based platform for server-side and networking applications",
-      "categories": ["development"],
+      "categories": [
+        "development"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/node.png",
       "image": "node:latest",
@@ -64,11 +76,16 @@
       "type": 1,
       "title": "Nginx",
       "description": "High performance web server",
-      "categories": ["webserver"],
+      "categories": [
+        "webserver"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/nginx.png",
       "image": "nginx:latest",
-      "ports": ["80/tcp", "443/tcp"],
+      "ports": [
+        "80/tcp",
+        "443/tcp"
+      ],
       "volumes": [
         {
           "container": "/etc/nginx"
@@ -82,11 +99,15 @@
       "type": 1,
       "title": "Httpd",
       "description": "Open-source HTTP server",
-      "categories": ["webserver"],
+      "categories": [
+        "webserver"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/httpd.png",
       "image": "httpd:latest",
-      "ports": ["80/tcp"],
+      "ports": [
+        "80/tcp"
+      ],
       "volumes": [
         {
           "container": "/usr/local/apache2/htdocs/"
@@ -97,11 +118,15 @@
       "type": 1,
       "title": "Caddy",
       "description": "Open-source web server with automatic HTTPS written in Go",
-      "categories": ["webserver"],
+      "categories": [
+        "webserver"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/caddy.png",
       "image": "caddy:latest",
-      "ports": ["80/tcp"],
+      "ports": [
+        "80/tcp"
+      ],
       "volumes": [
         {
           "container": "/data"
@@ -112,7 +137,9 @@
       "type": 1,
       "title": "MySQL",
       "description": "The most popular open-source database",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mysql.png",
       "image": "mysql/mysql-server:5.7",
@@ -127,7 +154,9 @@
           "preset": true
         }
       ],
-      "ports": ["3306/tcp"],
+      "ports": [
+        "3306/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/mysql"
@@ -138,7 +167,9 @@
       "type": 1,
       "title": "MariaDB",
       "description": "Performance beyond MySQL",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mariadb.png",
       "image": "mariadb:latest",
@@ -148,7 +179,9 @@
           "label": "Root password"
         }
       ],
-      "ports": ["3306/tcp"],
+      "ports": [
+        "3306/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/mysql"
@@ -159,7 +192,9 @@
       "type": 1,
       "title": "PostgreSQL",
       "description": "The most advanced open-source database",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/postgres.png",
       "image": "postgres:latest",
@@ -173,7 +208,9 @@
           "label": "Superuser password"
         }
       ],
-      "ports": ["5432/tcp"],
+      "ports": [
+        "5432/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/postgresql/data"
@@ -184,11 +221,15 @@
       "type": 1,
       "title": "Mongo",
       "description": "Open-source document-oriented database",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mongo.png",
       "image": "mongo:latest",
-      "ports": ["27017/tcp"],
+      "ports": [
+        "27017/tcp"
+      ],
       "volumes": [
         {
           "container": "/data/db"
@@ -199,11 +240,16 @@
       "type": 1,
       "title": "CrateDB",
       "description": "An open-source distributed SQL database",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cratedb.png",
       "image": "crate:latest",
-      "ports": ["4200/tcp", "4300/tcp"],
+      "ports": [
+        "4200/tcp",
+        "4300/tcp"
+      ],
       "volumes": [
         {
           "container": "/data"
@@ -214,11 +260,16 @@
       "type": 1,
       "title": "Elasticsearch",
       "description": "Open-source search and analytics engine",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/elasticsearch.png",
       "image": "docker.elastic.co/elasticsearch/elasticsearch:7.15.1",
-      "ports": ["9200/tcp", "9300/tcp"],
+      "ports": [
+        "9200/tcp",
+        "9300/tcp"
+      ],
       "volumes": [
         {
           "container": "/usr/share/elasticsearch/data"
@@ -230,11 +281,18 @@
       "title": "GitLab CE",
       "description": "Open-source end-to-end software development platform",
       "note": "Default username is <b>root</b>. Check the <a href=\"https://docs.gitlab.com/ee/install/docker.html\" target=\"_blank\">GitLab documentation</a> to get started.",
-      "categories": ["development", "project-management"],
+      "categories": [
+        "development",
+        "project-management"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/gitlab_ce.png",
       "image": "gitlab/gitlab-ce:latest",
-      "ports": ["80/tcp", "443/tcp", "22/tcp"],
+      "ports": [
+        "80/tcp",
+        "443/tcp",
+        "22/tcp"
+      ],
       "volumes": [
         {
           "container": "/etc/gitlab"
@@ -251,11 +309,16 @@
       "type": 1,
       "title": "Minio",
       "description": "A distributed object storage server built for cloud applications and devops",
-      "categories": ["storage"],
+      "categories": [
+        "storage"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/minio.png",
       "image": "quay.io/minio/minio:latest",
-      "ports": ["9000/tcp", "9001/tcp"],
+      "ports": [
+        "9000/tcp",
+        "9001/tcp"
+      ],
       "env": [
         {
           "name": "MINIO_ROOT_USER",
@@ -280,11 +343,15 @@
       "type": 1,
       "title": "Scality S3",
       "description": "Standalone AWS S3 protocol server",
-      "categories": ["storage"],
+      "categories": [
+        "storage"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/scality-s3.png",
       "image": "scality/s3server",
-      "ports": ["8000/tcp"],
+      "ports": [
+        "8000/tcp"
+      ],
       "env": [
         {
           "name": "SCALITY_ACCESS_KEY",
@@ -308,12 +375,16 @@
       "type": 1,
       "title": "SQL Server",
       "description": "Microsoft SQL Server on Linux",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
       "image": "mcr.microsoft.com/mssql/server:2019-latest",
-      "ports": ["1433/tcp"],
+      "ports": [
+        "1433/tcp"
+      ],
       "env": [
         {
           "name": "ACCEPT_EULA",
@@ -330,12 +401,16 @@
       "type": 1,
       "title": "SQL Server",
       "description": "Microsoft SQL Server Developer for Windows containers",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "windows",
       "note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
       "image": "microsoft/mssql-server-windows-developer:latest",
-      "ports": ["1433/tcp"],
+      "ports": [
+        "1433/tcp"
+      ],
       "env": [
         {
           "name": "ACCEPT_EULA",
@@ -357,12 +432,16 @@
       "type": 1,
       "title": "SQL Server Express",
       "description": "Microsoft SQL Server Express for Windows containers",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "windows",
       "note": "Password needs to include at least 8 characters including uppercase, lowercase letters, base-10 digits and/or non-alphanumeric symbols.",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
       "image": "microsoft/mssql-server-windows-express:latest",
-      "ports": ["1433/tcp"],
+      "ports": [
+        "1433/tcp"
+      ],
       "env": [
         {
           "name": "ACCEPT_EULA",
@@ -384,11 +463,15 @@
       "type": 1,
       "title": "Solr",
       "description": "Open-source enterprise search platform",
-      "categories": ["search-engine"],
+      "categories": [
+        "search-engine"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/solr.png",
       "image": "solr:latest",
-      "ports": ["8983/tcp"],
+      "ports": [
+        "8983/tcp"
+      ],
       "volumes": [
         {
           "container": "/opt/solr/mydata"
@@ -399,48 +482,54 @@
       "type": 1,
       "title": "Redis",
       "description": "Open-source in-memory data structure store",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redis.png",
       "image": "redis:latest",
-      "ports": ["6379/tcp"],
+      "ports": [
+        "6379/tcp"
+      ],
       "volumes": [
         {
           "container": "/data"
         }
       ]
     },
-		{
-			"type": 2,
-			"title": "Swarm monitoring",
-			"description": "Monitor your cluster performances with Prometheus & Grafana",
-			"note": "Requires Docker version 19.03.0+. <b>Make sure to add the <code>monitoring == true</code> one of your Swarm manager node before deploying this stack.</b>",
-			"categories": [
-				"Monitoring"
-			],
-			"platform": "linux",
-			"logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
-			"repository": {
-				"url": "https://github.com/portainer/templates",
-				"stackfile": "swarm/monitoring/docker-compose.yml"
-			},
-			"env": [
-				{
-					"name": "GRAFANA_USER",
-					"label": "Grafana admin user",
-					"default": "admin"
-				},
-				{
-					"name": "GRAFANA_PASSWORD",
-					"label": "Grafana admin password"
-				}
-			]
-		},    
+    {
+      "type": 2,
+      "title": "Swarm monitoring",
+      "description": "Monitor your cluster performances with Prometheus & Grafana",
+      "note": "Requires Docker version 19.03.0+. <b>Make sure to add the <code>monitoring == true</code> one of your Swarm manager node before deploying this stack.</b>",
+      "categories": [
+        "Monitoring"
+      ],
+      "platform": "linux",
+      "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "swarm/monitoring/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "GRAFANA_USER",
+          "label": "Grafana admin user",
+          "default": "admin"
+        },
+        {
+          "name": "GRAFANA_PASSWORD",
+          "label": "Grafana admin password"
+        }
+      ]
+    },
     {
       "type": 2,
       "title": "Redis Cluster",
       "description": "Open-source in-memory data structure store - Cluster mode",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redis.png",
       "repository": {
@@ -458,11 +547,16 @@
       "type": 1,
       "title": "RabbitMQ",
       "description": "Highly reliable enterprise messaging system",
-      "categories": ["messaging"],
+      "categories": [
+        "messaging"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/rabbitmq.png",
       "image": "rabbitmq:latest",
-      "ports": ["5671/tcp", "5672/tcp"],
+      "ports": [
+        "5671/tcp",
+        "5672/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/rabbitmq"
@@ -473,12 +567,16 @@
       "type": 1,
       "title": "Ghost",
       "description": "Free and open-source blogging platform",
-      "categories": ["blog"],
+      "categories": [
+        "blog"
+      ],
       "note": "Access the blog management interface under <code>/ghost/</code>.",
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ghost.png",
       "image": "ghost:latest",
-      "ports": ["2368/tcp"],
+      "ports": [
+        "2368/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/lib/ghost/content"
@@ -489,7 +587,9 @@
       "type": 1,
       "title": "Joomla",
       "description": "Another free and open-source CMS",
-      "categories": ["CMS"],
+      "categories": [
+        "CMS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/joomla.png",
       "image": "joomla:latest",
@@ -504,7 +604,9 @@
           "label": "Database password"
         }
       ],
-      "ports": ["80/tcp"],
+      "ports": [
+        "80/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/www/html"
@@ -515,11 +617,15 @@
       "type": 1,
       "title": "Drupal",
       "description": "Open-source content management framework",
-      "categories": ["CMS"],
+      "categories": [
+        "CMS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/drupal.png",
       "image": "drupal:latest",
-      "ports": ["80/tcp"],
+      "ports": [
+        "80/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/www/html"
@@ -531,11 +637,15 @@
       "title": "Plone",
       "description": "A free and open-source CMS built on top of Zope",
       "note": "Default user and password are admin/admin",
-      "categories": ["CMS"],
+      "categories": [
+        "CMS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/plone.png",
       "image": "plone:latest",
-      "ports": ["8080/tcp"],
+      "ports": [
+        "8080/tcp"
+      ],
       "volumes": [
         {
           "container": "/data"
@@ -546,7 +656,10 @@
       "type": 1,
       "title": "Sematext Docker Agent",
       "description": "Collect logs, metrics and docker events",
-      "categories": ["Log Management", "Monitoring"],
+      "categories": [
+        "Log Management",
+        "Monitoring"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
       "image": "sematext/sematext-agent-docker:latest",
@@ -573,7 +686,9 @@
       "type": 1,
       "title": "Datadog agent",
       "description": "Collect events and metrics",
-      "categories": ["Monitoring"],
+      "categories": [
+        "Monitoring"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
       "image": "datadog/agent:latest",
@@ -605,7 +720,9 @@
       "type": 1,
       "title": "Mautic",
       "description": "Open-source marketing automation platform",
-      "categories": ["marketing"],
+      "categories": [
+        "marketing"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/mautic.png",
       "image": "mautic/mautic:latest",
@@ -620,7 +737,9 @@
           "label": "Database password"
         }
       ],
-      "ports": ["80/tcp"],
+      "ports": [
+        "80/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/www/html"
@@ -631,11 +750,16 @@
       "type": 1,
       "title": "Jenkins",
       "description": "Open-source continuous integration tool",
-      "categories": ["continuous-integration"],
+      "categories": [
+        "continuous-integration"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/jenkins.png",
       "image": "jenkins/jenkins:lts-jdk11",
-      "ports": ["8080/tcp", "50000/tcp"],
+      "ports": [
+        "8080/tcp",
+        "50000/tcp"
+      ],
       "volumes": [
         {
           "container": "/var/jenkins_home"
@@ -647,11 +771,15 @@
       "title": "Redmine",
       "description": "Open-source project management tool",
       "note": "Default user and password are admin/admin",
-      "categories": ["project-management"],
+      "categories": [
+        "project-management"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/redmine.png",
       "image": "redmine:latest",
-      "ports": ["3000/tcp"],
+      "ports": [
+        "3000/tcp"
+      ],
       "volumes": [
         {
           "container": "/usr/src/redmine/files"
@@ -663,11 +791,16 @@
       "title": "File browser",
       "description": "A web file manager",
       "note": "Default credentials: admin/admin",
-      "categories": ["filesystem", "storage"],
+      "categories": [
+        "filesystem",
+        "storage"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/filebrowser.png",
       "image": "filebrowser/filebrowser:latest",
-      "ports": ["80/tcp"],
+      "ports": [
+        "80/tcp"
+      ],
       "volumes": [
         {
           "container": "/data"
@@ -682,7 +815,9 @@
       "type": 1,
       "title": "CommandBox",
       "description": "ColdFusion (CFML) CLI",
-      "categories": ["development"],
+      "categories": [
+        "development"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-commandbox.png",
       "image": "ortussolutions/commandbox:latest",
@@ -693,13 +828,18 @@
           "preset": true
         }
       ],
-      "ports": ["8080/tcp", "8443/tcp"]
+      "ports": [
+        "8080/tcp",
+        "8443/tcp"
+      ]
     },
     {
       "type": 1,
       "title": "ContentBox",
       "description": "Open-source modular CMS",
-      "categories": ["CMS"],
+      "categories": [
+        "CMS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ortussolutions-contentbox.png",
       "image": "ortussolutions/contentbox:latest",
@@ -720,7 +860,10 @@
           "preset": true
         }
       ],
-      "ports": ["8080/tcp", "8443/tcp"],
+      "ports": [
+        "8080/tcp",
+        "8443/tcp"
+      ],
       "volumes": [
         {
           "container": "/data/contentbox/db"
@@ -734,20 +877,28 @@
       "type": 1,
       "title": "Dokku",
       "description": "Dokku setup as a container",
-      "categories": ["PaaS"],
+      "categories": [
+        "PaaS"
+      ],
       "platform": "linux",
       "logo": "",
-      "image":"dokku/dokku",
-      "ports": ["22/tcp", "80/tcp", "443/tcp"],
-      "volumes": [{
-        "container": "/mnt/dokku",
-        "bind": "/var/lib/dokku"
-      },
-      {
-        "container": "/var/run/docker.sock",
-        "bind": "/var/run/docker.sock"
-      }],
-      "env":[
+      "image": "dokku/dokku",
+      "ports": [
+        "22/tcp",
+        "80/tcp",
+        "443/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/mnt/dokku",
+          "bind": "/var/lib/dokku"
+        },
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock"
+        }
+      ],
+      "env": [
         {
           "name": "DOKKU_HOSTNAME",
           "label": "Dokku hostname",
@@ -766,11 +917,17 @@
       "title": "OPC Router",
       "description": "No-code middleware for industrial applications. The OPC Router connects PLCs, PCS, SCADA, MES, SQL databases and servers, label printers, e-mail servers and erp-systems via OPC UA, MQTT, REST, CSV and many others without any programming effort",
       "note": "More information about the <a href=\"https://www.opc-router.com/terms-of-use-and-eula/?utm_source=DockerHub_runtime&utm_medium=click&utm_campaign=TermsOfUseAndEula\" target=\"_blank\">EULA</a>.",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/opc-router.png",
       "image": "opcrouter/runtime:latest",
-      "ports": ["49429/tcp", "8080/tcp", "8081/tcp"],
+      "ports": [
+        "49429/tcp",
+        "8080/tcp",
+        "8081/tcp"
+      ],
       "env": [
         {
           "name": "INITIAL_USERNAME",
@@ -799,20 +956,24 @@
         {
           "container": "/inray"
         },
-	      {
+        {
           "container": "/var/log/opcrouter"
-        }      
+        }
       ]
     },
     {
       "type": 1,
       "title": "Floating License Server",
       "description": "License Server for Softing edgeConnector products",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
       "image": "softingindustrial/floating-license-server:latest",
-      "ports": ["6200/tcp"],
+      "ports": [
+        "6200/tcp"
+      ],
       "interactive": true,
       "volumes": [
         {
@@ -824,41 +985,65 @@
       "type": 1,
       "title": "EdgeConnector Modbus",
       "description": "Connect Modbus TCP Sensors/PLCs and provide the data via OPC UA and MQTT",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
       "image": "softingindustrial/edgeconnector-modbus:latest",
-      "ports": ["443/tcp", "8099/tcp", "4897/tcp"]
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ]
     },
     {
       "type": 1,
       "title": "EdgeConnector 840D",
       "description": "Access Siemens SINUMERIK 840D sl/pl controllers and provide data via OPC UA and MQTT",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
       "image": "softingindustrial/edgeconnector-840d",
-      "ports": ["443/tcp", "8099/tcp", "4897/tcp"]
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ]
     },
     {
       "type": 1,
       "title": "EdgeConnector Siemens",
       "description": "Connect Siemens SIMATIC S7-300/400/1200/1500 PLCs and provide the data via OPC UA and MQTT",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
       "image": "softingindustrial/edgeconnector-siemens",
-      "ports": ["443/tcp", "8099/tcp", "4897/tcp"]
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ]
     },
     {
       "type": 1,
       "title": "EdgeConnector FANUC CNC",
       "description": "Connect FANUC CNCs and provide the data via OPC UA and MQTT",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
       "image": "softingindustrial/edgeconnector-fanuc-cnc",
-      "ports": ["443/tcp", "8099/tcp", "4897/tcp"],
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
       "env": [
         {
           "name": "TZ",
@@ -871,18 +1056,24 @@
         },
         {
           "container": "/mqtt"
-        }     
+        }
       ]
     },
     {
       "type": 1,
       "title": "EdgeConnector Aggregator",
       "description": "Offers a powerful OPC UA aggregation service which provides data via OPC UA, as well as MQTT",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/softing.png",
       "image": "softingindustrial/edgeaggregator",
-      "ports": ["443/tcp", "8099/tcp", "4897/tcp"],
+      "ports": [
+        "443/tcp",
+        "8099/tcp",
+        "4897/tcp"
+      ],
       "env": [
         {
           "name": "TZ",
@@ -895,7 +1086,7 @@
         },
         {
           "container": "/mqtt"
-        }     
+        }
       ]
     },
     {
@@ -903,7 +1094,9 @@
       "title": "Portainer Agent",
       "description": "Manage all the resources in your Swarm cluster",
       "note": "The agent will be deployed globally inside your cluster and available on port 9001.",
-      "categories": ["portainer"],
+      "categories": [
+        "portainer"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/portainer.png",
       "repository": {
@@ -917,7 +1110,9 @@
       "name": "func",
       "description": "Serverless functions made simple",
       "note": "Deploys the API gateway and sample functions. You can access the UI on port 8080. <b>Warning</b>: the name of the stack must be 'func'.",
-      "categories": ["serverless"],
+      "categories": [
+        "serverless"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/openfaas.png",
       "repository": {
@@ -930,7 +1125,9 @@
       "title": "IronFunctions",
       "description": "Open-source serverless computing platform",
       "note": "Deploys the IronFunctions API and UI.",
-      "categories": ["serverless"],
+      "categories": [
+        "serverless"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/ironfunctions.png",
       "repository": {
@@ -943,7 +1140,9 @@
       "title": "CockroachDB",
       "description": "CockroachDB cluster",
       "note": "Deploys an insecure CockroachDB cluster, please refer to <a href=\"https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-docker-swarm.html\" target=\"_blank\">CockroachDB documentation</a> for production deployments.",
-      "categories": ["database"],
+      "categories": [
+        "database"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cockroachdb.png",
       "repository": {
@@ -956,7 +1155,9 @@
       "title": "WordPress",
       "description": "WordPress setup with a MySQL database",
       "note": "Deploys a WordPress instance connected to a MySQL database.",
-      "categories": ["CMS"],
+      "categories": [
+        "CMS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wordpress.png",
       "repository": {
@@ -976,7 +1177,9 @@
       "title": "WordPress",
       "description": "WordPress setup with a MySQL database",
       "note": "Deploys a WordPress instance connected to a MySQL database.",
-      "categories": ["CMS"],
+      "categories": [
+        "CMS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/wordpress.png",
       "repository": {
@@ -996,7 +1199,9 @@
       "title": "OpenAMT",
       "description": "OpenAMT Cloud Toolkit",
       "note": "MPS password needs to be 8-32 characters including one uppercase, one lowercase letters, one base-10 digit and one special character.",
-      "categories": ["Cloud"],
+      "categories": [
+        "Cloud"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/intel.png",
       "repository": {
@@ -1041,7 +1246,9 @@
       "type": 2,
       "title": "Microsoft OMS Agent",
       "description": "Microsoft Operations Management Suite Linux agent.",
-      "categories": ["OPS"],
+      "categories": [
+        "OPS"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/microsoft.png",
       "repository": {
@@ -1064,7 +1271,10 @@
     {
       "title": "Sematext Docker Agent",
       "type": 2,
-      "categories": ["Log Management", "Monitoring"],
+      "categories": [
+        "Log Management",
+        "Monitoring"
+      ],
       "description": "Collect logs, metrics and docker events",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/sematext_agent.png",
       "platform": "linux",
@@ -1086,7 +1296,9 @@
     {
       "title": "Datadog agent",
       "type": 2,
-      "categories": ["Monitoring"],
+      "categories": [
+        "Monitoring"
+      ],
       "description": "Collect events and metrics",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/datadog_agent.png",
       "platform": "linux",
@@ -1126,7 +1338,9 @@
       "type": 3,
       "title": "Dokku",
       "description": "Dokku setup as a compose file",
-      "categories": ["PaaS"],
+      "categories": [
+        "PaaS"
+      ],
       "platform": "linux",
       "logo": "",
       "repository": {
@@ -1181,7 +1395,9 @@
       "type": 2,
       "title": "LiveSwitch",
       "description": "A basic LiveSwitch stack with gateway, caching, database and media server",
-      "categories": ["media"],
+      "categories": [
+        "media"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
@@ -1199,7 +1415,9 @@
       "type": 3,
       "title": "LiveSwitch",
       "description": "A basic LiveSwitch compose with gateway, caching, database and media server",
-      "categories": ["media"],
+      "categories": [
+        "media"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/liveswitch.png",
       "repository": {
@@ -1217,7 +1435,9 @@
       "type": 3,
       "title": "TOSIBOX Lock for Container",
       "description": "Lock for Container brings secure connectivity inside your industrial IoT devices",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/tosibox.png",
       "repository": {
@@ -1236,7 +1456,9 @@
       "title": "Pro Mosquitto with Management Center",
       "description": "Commercial-grade Mosquitto MQTT broker with Management Center",
       "note": "The Mosquitto broker password must be at least 12 characters.",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/cedalo.png",
       "repository": {
@@ -1311,7 +1533,9 @@
       "type": 3,
       "title": "Manubes Edge Node",
       "description": "High-performance cloud platform for industrial production management. Manubes is a no-code solution that is used to structure, monitor and control production data, systems and processes in the cloud.",
-      "categories": ["edge"],
+      "categories": [
+        "edge"
+      ],
       "platform": "linux",
       "logo": "https://portainer-io-assets.sfo2.digitaloceanspaces.com/logos/inray-manubes.png",
       "repository": {
@@ -1335,6 +1559,48 @@
           ]
         }
       ]
+    },
+    {
+      "type": 1,
+      "title": "HermitStash",
+      "description": "Post-quantum encrypted, self-hosted file uploads with ML-KEM-1024 hybrid encryption and zero plaintext on disk.",
+      "categories": [
+        "file-sharing",
+        "security",
+        "encryption"
+      ],
+      "platform": "linux",
+      "logo": "https://assets.hermitstash.com/img/icons/icon-512.png",
+      "image": "ghcr.io/dotcoocoo/hermitstash:latest",
+      "ports": [
+        "3000/tcp"
+      ],
+      "volumes": [
+        {
+          "container": "/app/data",
+          "bind": "/opt/hermitstash/data"
+        },
+        {
+          "container": "/app/uploads",
+          "bind": "/opt/hermitstash/uploads"
+        }
+      ],
+      "env": [
+        {
+          "name": "TRUST_PROXY",
+          "label": "Trust Proxy",
+          "default": "true",
+          "description": "Set to true if behind a reverse proxy"
+        },
+        {
+          "name": "RP_ORIGIN",
+          "label": "Site Origin URL",
+          "default": "",
+          "description": "Full URL (e.g. https://files.example.com). Required for passkeys and HSTS."
+        }
+      ],
+      "note": "Requires --shm-size=256m for the in-memory encrypted database. After starting, visit port 3000 to complete the setup wizard.",
+      "restart_policy": "unless-stopped"
     }
   ]
 }

--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -1563,7 +1563,7 @@
     {
       "type": 1,
       "title": "HermitStash",
-      "description": "Post-quantum encrypted, self-hosted file uploads with ML-KEM-1024 hybrid encryption and zero plaintext on disk.",
+      "description": "Post-quantum encrypted, self-hosted file uploads. Files are sealed with ML-KEM-1024 + P-384 hybrid KEM, XChaCha20-Poly1305, and Argon2id before touching disk. Includes WebAuthn passkey auth, TOTP 2FA (HMAC-SHA-512), shareable links with expiry/download limits, S3-compatible storage backend support, and an admin panel.",
       "categories": [
         "file-sharing",
         "security",
@@ -1621,7 +1621,7 @@
           "description": "Full URL (e.g. https://files.example.com). Required for passkeys and HSTS."
         }
       ],
-      "note": "Requires --shm-size=256m for the in-memory encrypted database. Recommended runtime flags (set under Advanced container settings -> Capabilities and Runtime & Resources): cap_drop=ALL with cap_add=CHOWN,SETUID,SETGID,DAC_OVERRIDE; security_opt no-new-privileges:true; init=true. After starting, visit port 3000 to complete the setup wizard.",
+      "note": "Requires --shm-size=256m for the in-memory encrypted database. Recommended runtime flags (set under Advanced container settings -> Capabilities and Runtime & Resources): cap_drop=ALL with cap_add=CHOWN,SETUID,SETGID,DAC_OVERRIDE; security_opt no-new-privileges:true; init=true; stop_grace_period=1m. After starting, visit port 3000 to complete the setup wizard. IMPORTANT: back up /app/data/vault.key after first run — losing it makes all encrypted data unrecoverable.",
       "restart_policy": "unless-stopped"
     }
   ]


### PR DESCRIPTION
## New template: HermitStash

Post-quantum encrypted, self-hosted file upload server.

**Image:** `ghcr.io/dotcoocoo/hermitstash:latest`
**Project:** https://github.com/dotCooCoo/hermitstash
**License:** AGPL-3.0-or-later

### Template includes
- Port 3000
- Persistent volumes for `/app/data` and `/app/uploads`
- `TRUST_PROXY` and `RP_ORIGIN` environment variables
- Note about `--shm-size=256m` requirement
- Logo icon from assets.hermitstash.com

### Features
- ML-KEM-1024 + P-384 hybrid encryption (FIPS 203)
- Zero plaintext on disk — vault-sealed database
- One-command deploy, admin panel for all configuration
- Multi-arch: linux/amd64 + linux/arm64