### PR TITLE
Add MaestroHub App Template

### DIFF
--- a/edge/maestrohub/docker-compose.yml
+++ b/edge/maestrohub/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  maestrohub:
+    image: us-docker.pkg.dev/maestrohubtests/maestrohub/maestrohub-lite:latest
+    container_name: maestrohub
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "8083:8083"
+    volumes:
+      - maestrohub-data:/data
+
+volumes:
+  maestrohub-data:

--- a/templates.json
+++ b/templates.json
@@ -1544,6 +1544,20 @@
         "url": "https://github.com/portainer/templates",
         "stackfile": "edge/litmusedge_dfd/docker-compose.yml"
       }
+    },
+    {
+      "id": 72,
+      "type": 3,
+      "title": "MaestroHub",
+      "description": "Industrial data orchestrator with a Unified Namespace, drag-and-drop pipelines, and 40+ protocol connectors. Built-in MCP server brings AI agents into your operational data stack.",
+      "note": "Welcome to MaestroHub!\n\n• Open http://&lt;host&gt;:8080 to create your admin account\n• MQTT clients can connect to &lt;host&gt;:1883 (TCP) or &lt;host&gt;:8083 (WebSocket)\n• Data persists in the maestrohub-data Docker volume — back it up before destroying the stack\n• Get started guide: https://docs.maestrohub.com/overview/get-started",
+      "categories": ["edge"],
+      "platform": "linux",
+      "logo": "https://avatars.githubusercontent.com/u/219120420?s=400&u=699c593f7490c79736e08eec580fd9af40278576&v=4",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "edge/maestrohub/docker-compose.yml"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds **MaestroHub** as an edge App Template on `portainer/templates@v3`.

MaestroHub is an industrial data orchestrator that connects OT and IT through a Unified Namespace (UNS). 40+ protocol connectors (Modbus, OPC-UA, S7, EtherNet/IP, BACnet, Sparkplug B, MQTT, Kafka, PostgreSQL, MySQL, MSSQL, Snowflake, BigQuery, S3, Azure Blob, Slack, REST, …) feed the namespace, and a built-in MCP (Model Context Protocol) server lets AI agents read, transform, and act on the resulting operational data without bespoke integrations.

The deployment shipped in this template is **MaestroHub Lite** — a single binary that runs every module (auth, RBAC, connectors, pipeline engine, scheduler, UNS, search, audit, websocket gateway, license, …) plus the embedded React UI in one container. There are **no external dependencies**: the embedded MQTT broker (Mosquitto-compatible) is on `:1883/:8083` and the historian uses Pebble against the persistent `/data` volume. A built-in MCP (Model Context Protocol) server is exposed so AI agents can query topics, run pipelines, and act on operational data without bespoke integrations.

## Why an edge template

MaestroHub Lite is built for the same niches as Litmus Edge, Inductive Automation Ignition, Inray manubes and Anyviz already on this list — single-VM / single-host industrial gateways and on-prem deployments where adding a Kubernetes layer is overkill. The existing edge templates focus on broker/connector layers; MaestroHub adds the orchestration + UNS + pipelines layer in the same form factor.

## Files added

| File | Change |
|---|---|
| `edge/maestrohub/docker-compose.yml` | new — single-service compose stack, 14 lines, zero env (matches the Litmus Edge / Anyviz / OPC Router pattern) |
| `templates.json` | one new entry at `id: 72`, category `edge`, type `3` (compose stack) |

## Image

`us-docker.pkg.dev/maestrohubtests/maestrohub/maestrohub-lite:latest`

- Hosted on a public GCP Artifact Registry repository — **anonymous-pullable**, no `gcloud auth` or DockerHub login required, no rate limits.
- Multi-arch manifest: `linux/amd64`, `linux/arm64` (with attestations).
- Runtime image size ≈ 76 MB.
- Runs as a non-root `maestrohub` user.
- OCI labels: `org.opencontainers.image.title=MaestroHub Lite`, `org.opencontainers.image.description=MaestroHub single-binary edge edition`.
- No secrets baked into the image — JWT/encryption keys are auto-generated on first boot and persisted to the `/data` volume; no env vars need to be supplied by the user.

## Compose layout

The stack is intentionally minimal:

| Section | Value |
|---|---|
| Service | `maestrohub` (single service) |
| Image | `…/maestrohub-lite:latest` |
| Restart policy | `unless-stopped` |
| Volume | named `maestrohub-data` mounted at `/data` (SQLite settings + Pebble historian + first-run secrets) |
| Healthcheck | inherited from the image (`wget /health`) — no override |
| Env | none |
| Build args / Dockerfile | none — image-only |

Ports exposed on the host:

| Port | Purpose |
|---|---|
| `8080` | HTTP API + embedded UI (admin setup, dashboards, pipeline editor, UNS browser) |
| `1883` | MQTT TCP — embedded broker for OT clients (PLCs, sensors, dashboards) |
| `8083` | MQTT WebSocket — for browser-based MQTT clients |

## Verification

The artifacts were validated end-to-end on a local Mac (`linux/arm64`) and an x86_64 Docker host before this PR was opened.

- [x] `template.json` validates against `schema.json` (CI will repeat this).
- [x] `id 72` does not collide with any current upstream entry (max upstream `id` was `71` at PR-open time).
- [x] Anonymous `docker pull` from `us-docker.pkg.dev/.../maestrohub-lite:latest` succeeds (multi-arch manifest selects the host platform automatically).
- [x] `compose config` parses cleanly (no `version` warning, no obsolete fields).
- [x] Deployed via Portainer 2.40 STS **Custom Templates UI** (compose paste) on Community Edition — container healthy, all 17 internal modules report UP within ~15 s, embedded MQTT broker listens on `:1883`, embedded historian connects, HTTP UI returns 200 at `:8080`.
- [x] Deployed via Portainer 2.40 STS **App Templates URL flow** on Business Edition by pointing the Portainer instance at a fork of this repo — card renders correctly (logo + description + note), repo is cloned, compose is fetched and stack deploys without intervention.
- [x] **Volume persistence** — destroyed the container and recreated it against the same named volume; the auto-generated instance UUID, `auth.db` and `uns.db` SHAs are preserved byte-for-byte.
- [x] **Container webhook** flow on Business Edition — POSTing to the per-container webhook URL recreates the container and pulls a fresh image without touching the volume.

## First-run UX

- Open `http://<host>:8080` → admin account creation wizard (no default credentials shipped).
- MQTT clients connect to `<host>:1883` (TCP) or `<host>:8083` (WebSocket); auth is configured later via the UNS UI.
- Stack data lives in the `maestrohub-data` Docker volume — back it up before destroying the stack.
- Get-started guide: https://docs.maestrohub.com/overview/get-started

## Edition note

MaestroHub Lite ships as the **Core** edition out of the box — fully usable for single-host on-prem deployments. Foundation (basic RBAC, SSO, OAuth2 clients) and Enterprise (Fleet manager, advanced access control) editions are unlocked with a license; no setup change is required at the template level.

Happy to iterate on description, logo, or any of the entry fields based on review feedback.
