### PR TITLE
Add Spokes App to templates

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1575,8 +1575,7 @@
         {
           "name": "SPOKES_MASTER_PASSWORD",
           "label": "Master Password",
-          "description": "Create a secure Master Password used to encrypt secure channels escrow.",
-          "default": "YourSecurePassword"
+          "description": "Create a secure Master Password used to encrypt secure channels escrow."
         }
       ]
     }

--- a/templates.json
+++ b/templates.json
@@ -1558,6 +1558,27 @@
         "url": "https://github.com/portainer/templates",
         "stackfile": "edge/maestrohub/docker-compose.yml"
       }
+    },
+    {
+      "type": 3,
+      "title": "Spokes",
+      "description": "Secure, self-hosted team chat with voice and video.",
+      "note": "Spokes requires a Master Password to encrypt your data.",
+      "categories": ["Communication", "Chat"],
+      "platform": "linux",
+      "logo": "https://spokes.sh/logo.png",
+      "repository": {
+        "url": "https://github.com/PCBeeQC/Spokes-Deploy",
+        "stackfile": "docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "SPOKES_MASTER_PASSWORD",
+          "label": "Master Password",
+          "description": "Create a secure Master Password used to encrypt secure channels escrow.",
+          "default": "YourSecurePassword"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?
Adds Spokes to the official Portainer App Templates.

Spokes is a self-hosted, secure communication platform designed for friend groups, families and small businesses. It features real-time chat, voice, and video channels.

### Implementation Notes
- **Stack Definition:** Points to our official public deployment repository `PCBeeQC/Spokes-Deploy`.
- **Environment Variables:** Includes a prompt for `SPOKES_MASTER_PASSWORD` to ensure users securely set their encryption key during the Portainer deployment wizard.

We've verified that the underlying `docker-compose.yml` stack deploys and operates correctly. Let us know if any adjustments are needed to the template JSON!