### PR TITLE
feat(template): add LibreDB Studio template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -847,5 +847,58 @@
         "bind": "/var/run/docker.sock"
       }
     ]
+  },
+  {
+    "type": "container",
+    "title": "LibreDB Studio",
+    "description": "Modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
+    "categories": [
+      "database"
+    ],
+    "platform": "linux",
+    "logo": "https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg",
+    "image": "ghcr.io/libredb/libredb-studio:v0.9.13",
+    "env": [
+      {
+        "name": "ADMIN_EMAIL",
+        "label": "Admin email",
+        "default": "admin@libredb.org"
+      },
+      {
+        "name": "ADMIN_PASSWORD",
+        "label": "Admin password"
+      },
+      {
+        "name": "USER_EMAIL",
+        "label": "User email",
+        "default": "user@libredb.org"
+      },
+      {
+        "name": "USER_PASSWORD",
+        "label": "User password"
+      },
+      {
+        "name": "JWT_SECRET",
+        "label": "JWT secret (min 32 chars)"
+      },
+      {
+        "name": "STORAGE_PROVIDER",
+        "label": "Storage provider",
+        "default": "sqlite",
+        "preset": true
+      },
+      {
+        "name": "STORAGE_SQLITE_PATH",
+        "label": "SQLite path",
+        "default": "/app/data/libredb-storage.db",
+        "preset": true
+      }
+    ],
+    "ports": [
+      "3000/tcp"
+    ],
+    "volumes": [
+      "/app/data"
+    ]
   }
 ]

--- a/templates.json
+++ b/templates.json
@@ -857,7 +857,7 @@
     ],
     "platform": "linux",
     "logo": "https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg",
-    "image": "ghcr.io/libredb/libredb-studio:v0.9.13",
+    "image": "ghcr.io/libredb/libredb-studio:v0.9.27",
     "env": [
       {
         "name": "ADMIN_EMAIL",


### PR DESCRIPTION
This PR adds **LibreDB Studio** to the template list — an MIT-licensed, AI-powered open-source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the browser.

Added a single container template:
- Image: `ghcr.io/libredb/libredb-studio:v0.9.27`
- Port: 3000
- Persistent volume: `/app/data`
- Configurable admin/user email and password, JWT secret
- SQLite storage by default (no external database required)

Links:
- GitHub: https://github.com/libredb/libredb-studio
- Website: https://libredb.org/