### PR TITLE
Update MaestroHub template image to public Docker Hub

### DIFF
--- a/edge/maestrohub/docker-compose.yml
+++ b/edge/maestrohub/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   maestrohub:
-    image: us-docker.pkg.dev/maestrohubtests/maestrohub/maestrohub-lite:latest
+    image: maestrohub/lite:latest
     container_name: maestrohub
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Points the MaestroHub edge template at our canonical public Docker Hub image (`maestrohub/lite:latest`) instead of the Google Artifact Registry mirror (`us-docker.pkg.dev/maestrohubtests/...`), following up on #255.

- `maestrohub/lite` on Docker Hub is our public distribution; the GAR path lived in an internal project.
- Same **multi-arch** image (linux/amd64 + linux/arm64); `:latest` tracks the newest stable release (currently 2.6.2).
- No functional change for users — identical image, more appropriate public source.
