### PR TITLE
feat(template): add new systemprompt template

### DIFF
--- a/stacks/systemprompt/docker-compose.yml
+++ b/stacks/systemprompt/docker-compose.yml
@@ -1,0 +1,58 @@
+# Canonical one-click catalog compose for the systemprompt gateway.
+# This is the artifact marketplace catalogs (Portainer, Dokploy, CasaOS,
+# CapRover derivatives) reference by raw URL. It runs the published GHCR
+# image; the root docker-compose.yml builds from source. Keep the service
+# and volume topology in sync — smoke-tests.yml `compose-drift` enforces it.
+services:
+  postgres:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: systemprompt
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-systemprompt}
+      POSTGRES_DB: systemprompt
+    volumes:
+      # postgres:18+ images store data under major-version subdirectories of
+      # /var/lib/postgresql — mounting the old .../data path aborts startup.
+      - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U systemprompt -d systemprompt"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    # Floating major tag: picks up minor/patch releases without a template bump.
+    image: ghcr.io/systempromptio/systemprompt-template:0
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://systemprompt:${POSTGRES_PASSWORD:-systemprompt}@postgres:5432/systemprompt
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # Public URL of this deployment (https://gateway.example.com);
+      # used for api_external_url + CORS. Optional.
+      EXTERNAL_URL: ${EXTERNAL_URL:-}
+      HOST: ${HOST:-0.0.0.0}
+      PORT: 8080
+    ports:
+      - "${HTTP_PORT:-8080}:8080"
+    volumes:
+      - app_web:/app/web
+      - app_storage_data:/app/storage/data
+      - app_profiles:/app/services/profiles/docker
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 300s
+      retries: 3
+
+volumes:
+  postgres_data:
+  app_web:
+  app_storage_data:
+  app_profiles:

--- a/templates.json
+++ b/templates.json
@@ -1875,6 +1875,57 @@
         "url": "https://github.com/portainer/templates",
         "stackfile": "edge/sorba-sde/docker-compose.yml"
       }
+    },
+    {
+      "id": 76,
+      "type": 3,
+      "title": "systemprompt",
+      "description": "Self-owned AI control plane: governance gateway for Claude, OpenAI, and Gemini with policy checks, audit, rate limits, and MCP orchestration. Bundles Postgres.",
+      "note": "Set at least one AI provider key or the gateway will not boot. First boot runs migrations and a publish pipeline; allow several minutes before the healthcheck passes. Optionally set EXTERNAL_URL to the public URL you will serve it on.",
+      "categories": ["AI", "Tools"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/systempromptio/systemprompt-template/main/storage/files/images/icon-256.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/systemprompt/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "POSTGRES_PASSWORD",
+          "label": "Postgres password",
+          "description": "Set before first deploy; the database volume is initialised with it."
+        },
+        {
+          "name": "ANTHROPIC_API_KEY",
+          "label": "Anthropic API key",
+          "description": "At least one provider key is required (leave others blank).",
+          "default": ""
+        },
+        {
+          "name": "OPENAI_API_KEY",
+          "label": "OpenAI API key",
+          "description": "Optional.",
+          "default": ""
+        },
+        {
+          "name": "GEMINI_API_KEY",
+          "label": "Gemini API key",
+          "description": "Optional.",
+          "default": ""
+        },
+        {
+          "name": "EXTERNAL_URL",
+          "label": "External URL",
+          "description": "Public URL of this deployment (e.g. https://gateway.example.com). Optional; used for API URL + CORS.",
+          "default": ""
+        },
+        {
+          "name": "HTTP_PORT",
+          "label": "HTTP port",
+          "description": "Host port to publish the gateway on.",
+          "default": "8080"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## feat(template): add new systemprompt template

Adds [systemprompt](https://github.com/systempromptio/systemprompt-template), a self-owned AI control plane: a governance gateway for Claude, OpenAI, and Gemini with policy checks, request audit, rate limits, cost tracking, and MCP server orchestration. Bundles Postgres.

**Changes**
- `templates.json`: new type-3 template, id 76
- `stacks/systemprompt/docker-compose.yml`: the stack file (app + Postgres, named volumes, healthchecks)

**Details**
- Image is publicly pullable: `ghcr.io/systempromptio/systemprompt-template:0` (floating major tag; minor/patch releases need no template bump).
- Requires at least one AI provider API key, surfaced as env vars with defaults and a note.
- First boot runs DB migrations and a publish pipeline; the app healthcheck has a 300s start period to cover it.
- Tested end to end: deployed through a local Portainer CE 2.39.5 instance using this exact template JSON and compose file, stack reached `healthy`, `/api/v1/health` returns `{"status":"healthy"}`.
- `templates.json` validates against `schema.json` (same check as the validate workflow).
