### PR TITLE
feat(template): add CineDock v3 template

### DIFF
--- a/stacks/cinedock/docker-compose.yml
+++ b/stacks/cinedock/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  cinedock:
+    image: ghcr.io/cinedock/cinedock:4.1.6
+    restart: unless-stopped
+    environment:
+      CONFIG_DIR: /config
+      PORT: "8945"
+      TMDB_API_KEY: ${TMDB_API_KEY:-}
+    ports:
+      - "${CINEDOCK_PORT:-8945}:8945"
+    volumes:
+      - cinedock-config:/config
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8945/', timeout=5)"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+volumes:
+  cinedock-config:

--- a/templates.json
+++ b/templates.json
@@ -1875,6 +1875,31 @@
         "url": "https://github.com/portainer/templates",
         "stackfile": "edge/sorba-sde/docker-compose.yml"
       }
+    },
+    {
+      "id": 77,
+      "type": 3,
+      "title": "CineDock",
+      "description": "A cinematic, television-first interface for the Emby, Jellyfin or Plex server you already run.",
+      "note": "After deployment, open http://&lt;host&gt;:&lt;CINEDOCK_PORT&gt; (8945 by default) and follow CineDock's setup wizard to connect your existing media server. CineDock does not scan, copy or change media files. The TMDB API key is optional.",
+      "categories": ["media"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/cinedock/unraid-templates/main/cinedock-icon.png",
+      "env": [
+        {
+          "name": "CINEDOCK_PORT",
+          "label": "Published web port",
+          "default": "8945"
+        },
+        {
+          "name": "TMDB_API_KEY",
+          "label": "TMDB API key (optional)"
+        }
+      ],
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/cinedock/docker-compose.yml"
+      }
     }
   ]
 }


### PR DESCRIPTION
## What changed

- Add CineDock 4.1.6 to the Portainer v3 template catalog.
- Add a linked Compose stack using the official multi-architecture GHCR image.
- Persist `/config` in a named volume and publish web port 8945 by default.
- Expose only the optional published-port and TMDB API key variables.

Closes #267.

## Why

CineDock provides a cinematic, television-first interface for an existing Emby, Jellyfin or Plex server. The template keeps media and authentication owned by that existing server and does not request GPU, media, Docker socket, privileged, or host-path access.

## Validation

- Portainer's exact `orrosenblatt/validate-json-action:latest` PR validator passed against `schema.json` and `templates.json`.
- `docker compose config --quiet` passed for the linked stack.
- The linked stack started successfully and reached `healthy`.
- `/` returned HTTP 200.
- `/tvapp-version.json` returned `{build:4.1.6}`.
- Runtime inspection confirmed one named volume mounted at `/config` and only port 8945 published.
- The 4.1.6 image manifest contains linux/amd64 and linux/arm64.

## User impact

Users can deploy CineDock from Portainer's v3 catalog, open the published web port, and connect their existing media server through CineDock's setup wizard.