### PR TITLE
feat(template): add dockroute template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1875,6 +1875,71 @@
         "url": "https://github.com/portainer/templates",
         "stackfile": "edge/sorba-sde/docker-compose.yml"
       }
+    },
+    {
+      "id": 76,
+      "type": 1,
+      "title": "DockRoute",
+      "description": "External-DNS for plain Docker hosts: watches running containers, reads dockroute.* labels and reconciles the matching DNS records - and Cloudflare Tunnel routes - in a pluggable provider. TXT-based ownership means it never alters records it cannot prove it manages. Docs: https://www.dockroute.dev",
+      "categories": [
+        "docker",
+        "networking",
+        "dns"
+      ],
+      "platform": "linux",
+      "logo": "https://github.com/Dockroute.png",
+      "image": "ghcr.io/dockroute/dockroute:latest",
+      "restart_policy": "unless-stopped",
+      "note": "Socket permissions are handled automatically: the entrypoint grants the app user the Docker socket's group and drops privileges before starting. Start with the default log provider for a zero-credential dry run, then switch to cloudflare. Opt containers in with labels: dockroute.enabled=true and dockroute.hostname=app.example.com.",
+      "env": [
+        {
+          "name": "DOCKROUTE_PROVIDER",
+          "label": "Provider (log = dry run, cloudflare)",
+          "default": "log"
+        },
+        {
+          "name": "DOCKROUTE_OWNER_ID",
+          "label": "Ownership id (lets several instances share a zone)",
+          "default": "default"
+        },
+        {
+          "name": "DOCKROUTE_POLICY",
+          "label": "Sync policy (sync, upsert-only, create-only)",
+          "default": "sync"
+        },
+        {
+          "name": "DOCKROUTE_DEFAULT_TARGET",
+          "label": "Default record target (IP or CNAME)",
+          "default": ""
+        },
+        {
+          "name": "DOCKROUTE_DOMAIN_FILTER",
+          "label": "Comma-separated zone allowlist (empty = all)",
+          "default": ""
+        },
+        {
+          "name": "CLOUDFLARE_API_TOKEN",
+          "label": "Cloudflare API token (required for cloudflare provider)",
+          "default": ""
+        },
+        {
+          "name": "CLOUDFLARE_ACCOUNT_ID",
+          "label": "Cloudflare account id (tunnel publishing only)",
+          "default": ""
+        },
+        {
+          "name": "CLOUDFLARE_TUNNEL_ID",
+          "label": "Cloudflare tunnel id (tunnel publishing only)",
+          "default": ""
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock",
+          "readonly": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds [DockRoute](https://www.dockroute.dev) ([source](https://github.com/Dockroute/Dockroute), MIT) to the v3 template list.

DockRoute is External-DNS for plain Docker hosts: it watches running containers, reads `dockroute.*` labels and reconciles the matching DNS records — and Cloudflare Tunnel routes — in a pluggable provider. ExternalDNS-style TXT ownership means it never alters records it cannot prove it manages.

Template details:
- `type` 1, next free `id` (76), appended at the end of the array — no changes to existing entries.
- Deploys with zero required configuration: the default `log` provider is a credential-free dry run, and the image handles Docker socket permissions itself (starts as root only to grant the app user the socket's group, then drops privileges; main process runs as non-root).
- Image is multi-arch (amd64 + arm64) on GHCR, published by the project's release pipeline with Trivy gating.

Validated: the file parses and the new entry conforms to the v3 app-template format.