### PR TITLE
fix(addons): probe portainer-run on /healthz [R8S-1239]

### DIFF
--- a/addons/addons-catalog-develop.json
+++ b/addons/addons-catalog-develop.json
@@ -21,7 +21,7 @@
       "icon": "/assets/addons/portainer-run.svg",
       "path": "/addons/portainer-run",
       "serviceUrl": "http://portainer-run.portainer-addon-portainer-run.svc.cluster.local",
-      "healthCheckPath": "/config"
+      "healthCheckPath": "/healthz"
     }
   ]
 }

--- a/addons/addons-catalog.json
+++ b/addons/addons-catalog.json
@@ -10,7 +10,7 @@
       "icon": "/assets/addons/portainer-run.svg",
       "path": "/addons/portainer-run",
       "serviceUrl": "http://portainer-run.portainer-addon-portainer-run.svc.cluster.local",
-      "healthCheckPath": "/config"
+      "healthCheckPath": "/healthz"
     }
   ]
 }


### PR DESCRIPTION
/config answers 200 whatever the credential is doing, so Portainer reports a locked-out add-on as healthy. /healthz answers 401 once the credential is rejected, which Portainer reads as credential-invalid and offers a repair for.

The catalog is one global document with no version gating, so this reaches every installation at once. Safe there: portainer-run serves index.html for any extensionless unknown path, so an image predating /healthz answers 200, and a 404 on the health path counts as healthy anyway.

portal-template keeps /readyz.