### PR TITLE
feat(template): add Borg UI (container and stack with Redis)

### DIFF
--- a/stacks/borg-ui/docker-compose.yml
+++ b/stacks/borg-ui/docker-compose.yml
@@ -1,0 +1,54 @@
+# Borg UI + Redis stack for the Portainer app template (templates.json, type 3).
+# Environment variables are supplied by Portainer from the template's "env" list.
+services:
+  borg-ui:
+    image: ainullcode/borg-ui:latest
+    restart: unless-stopped
+    ports:
+      - "${PORT:-8081}:${PORT:-8081}"
+    volumes:
+      - borg_data:/data
+      - borg_cache:/home/borg/.cache/borg
+      - /etc/localtime:/etc/localtime:ro
+      - ${LOCAL_STORAGE_PATH:-/home}:/local:rw
+    environment:
+      - PORT=${PORT:-8081}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+      - LOCAL_MOUNT_POINTS=/local
+      - INITIAL_ADMIN_PASSWORD=${INITIAL_ADMIN_PASSWORD:?Set INITIAL_ADMIN_PASSWORD to the password for the admin user}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_DB=0
+    # Optional FUSE access for archive mounting / SSHFS pull backups. Uncomment all four lines together.
+    # cap_add:
+    #   - SYS_ADMIN
+    # devices:
+    #   - /dev/fuse:/dev/fuse
+    # security_opt:
+    #   - apparmor:unconfined
+    # (and add BORG_FUSE_IMPL=pyfuse3 to environment)
+    healthcheck:
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:$${PORT:-8081}/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --maxmemory ${REDIS_MAXMEMORY:-512mb} --maxmemory-policy allkeys-lru --save "" --appendonly no
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+volumes:
+  borg_data:
+  borg_cache:

--- a/templates.json
+++ b/templates.json
@@ -1875,6 +1875,129 @@
         "url": "https://github.com/portainer/templates",
         "stackfile": "edge/sorba-sde/docker-compose.yml"
       }
+    },
+    {
+      "id": 76,
+      "type": 1,
+      "title": "Borg UI",
+      "name": "borg-ui",
+      "description": "Web interface for BorgBackup. Run backups, browse and restore archives, manage local, SSH and SFTP repositories and automate schedules. Single container, no Redis (in-memory archive cache).",
+      "note": "Login as <b>admin</b> with the initial admin password you set; you are asked to change it at first login. Map the folders you want to back up to /local. Redis is optional: set Redis host to an existing Redis to enable a persistent archive cache. Archive mounting and SSHFS pull backups need FUSE (SYS_ADMIN + /dev/fuse); use the stack template or docs for that. Docs: https://docs.borgui.com/installation",
+      "categories": ["storage"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/karanhudia/borg-ui/main/frontend/public/logo-rounded.png",
+      "image": "ainullcode/borg-ui:latest",
+      "restart_policy": "unless-stopped",
+      "ports": ["8081:8081/tcp"],
+      "volumes": [
+        {
+          "container": "/data",
+          "bind": "/opt/borg-ui/data"
+        },
+        {
+          "container": "/home/borg/.cache/borg",
+          "bind": "/opt/borg-ui/cache"
+        },
+        {
+          "container": "/local",
+          "bind": "/home"
+        },
+        {
+          "container": "/etc/localtime",
+          "bind": "/etc/localtime",
+          "readonly": true
+        }
+      ],
+      "env": [
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1000",
+          "description": "User ID that owns backup files."
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "1000",
+          "description": "Group ID that owns backup files."
+        },
+        {
+          "name": "TZ",
+          "label": "Timezone",
+          "default": "Etc/UTC"
+        },
+        {
+          "name": "LOCAL_MOUNT_POINTS",
+          "label": "Local mount points",
+          "default": "/local",
+          "description": "Comma-separated container paths shown in the file browser."
+        },
+        {
+          "name": "INITIAL_ADMIN_PASSWORD",
+          "label": "Initial admin password",
+          "description": "Password for the admin user, used on first start only. Required; you are asked to change it at first login."
+        },
+        {
+          "name": "REDIS_HOST",
+          "label": "Redis host",
+          "default": "disabled",
+          "description": "Leave 'disabled' for the in-memory cache, or set the hostname or IP of an existing Redis (port 6379). For a URL with auth, add a REDIS_URL variable under advanced options."
+        }
+      ]
+    },
+    {
+      "id": 77,
+      "type": 3,
+      "title": "Borg UI + Redis",
+      "name": "borg-ui-redis",
+      "description": "Borg UI with a bundled Redis cache for faster, persistent archive browsing. Compose stack (Borg UI + redis:7-alpine).",
+      "note": "Set LOCAL_STORAGE_PATH to the host folder to back up (mounted at /local). Login as <b>admin</b> with the INITIAL_ADMIN_PASSWORD you set; you are asked to change it at first login. To enable FUSE for archive mounting, uncomment the cap_add/devices/security_opt lines in the stack file, see https://docs.borgui.com/installation#optional-fuse-access",
+      "categories": ["storage"],
+      "platform": "linux",
+      "logo": "https://raw.githubusercontent.com/karanhudia/borg-ui/main/frontend/public/logo-rounded.png",
+      "repository": {
+        "url": "https://github.com/portainer/templates",
+        "stackfile": "stacks/borg-ui/docker-compose.yml"
+      },
+      "env": [
+        {
+          "name": "PORT",
+          "label": "Web UI port",
+          "default": "8081"
+        },
+        {
+          "name": "LOCAL_STORAGE_PATH",
+          "label": "Host folder to back up",
+          "default": "/home",
+          "description": "Mounted read-write at /local inside the container."
+        },
+        {
+          "name": "PUID",
+          "label": "PUID",
+          "default": "1000"
+        },
+        {
+          "name": "PGID",
+          "label": "PGID",
+          "default": "1000"
+        },
+        {
+          "name": "TZ",
+          "label": "Timezone",
+          "default": "Etc/UTC"
+        },
+        {
+          "name": "INITIAL_ADMIN_PASSWORD",
+          "label": "Initial admin password",
+          "description": "Password for the admin user, used on first start only. Required; you are asked to change it at first login."
+        },
+        {
+          "name": "REDIS_MAXMEMORY",
+          "label": "Redis max memory",
+          "default": "512mb",
+          "description": "Upper bound for the Redis cache (allkeys-lru eviction)."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds Borg UI, an AGPL web interface for BorgBackup: encrypted, deduplicated backups with schedules, archive browsing, single-file restore, SSH/SFTP and rclone repositories, and notifications. ~2,800 active installs, 1,600 GitHub stars, image on Docker Hub as `ainullcode/borg-ui`.

Two templates, ids 76 and 77:

- **Borg UI** (type 1): single container, in-memory archive cache, no Redis.
- **Borg UI + Redis** (type 3): Compose stack with a bundled Redis for a persistent cache, stack file under `stacks/borg-ui/`.

Both run non-privileged; FUSE for archive mounting is opt-in and documented in the note. The same templates are published from the project repo at `karanhudia/borg-ui/distribution/portainer/` and have been deployed from a Portainer 2.27 CE instance.

Project: https://github.com/karanhudia/borg-ui
Docs: https://docs.borgui.com